### PR TITLE
Add lumen.yaml to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ build/
 *.env
 models.yaml
 config.yaml
+lumen.yaml
 
 *.db
 *.sqlite


### PR DESCRIPTION
The `Dockerfile` does `COPY . .`, and `.dockerignore` excluded `config.yaml` and `models.yaml` but not `lumen.yaml`. A local `lumen.yaml` in the build context could therefore be baked into the image. This adds `lumen.yaml` to `.dockerignore` as defense-in-depth.

CI builds are already clean (the file is untracked), so this guards local/ad-hoc builds and prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)