### PR TITLE
Add /connect page for client configuration & usage examples (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Lumen will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- A **Connect your tools** page (`/connect`) that generates ready-to-use client configuration: a downloadable OpenCode (`opencode.ai`) `opencode.json` pre-filled with every model your account can access (keyed off the `LUMEN_API_KEY` environment variable), plus copy-paste **curl** and **Python** examples. Picking a specific model tailors the curl/Python snippets, including vision (`image_url`) examples for image-capable models and chat + `/v1/audio/transcriptions` examples for audio-capable models. The page is linked from the Models dashboard, each model detail page (pre-selecting that model), and the API-key sections of the profile and client pages, and is documented in a new "Connect Your Tools" help guide. Thanks to Josh Henry for the idea.
+
 ### Fixed
 - The "Total Users (Cumulative)" usage graph now shows the actual total user count instead of only the users created within the selected period. For non-"all" periods (week/month/year) the cumulative line restarted from zero at the start of the window, so an installation with 105 users would show 1–5 over the week. The query now seeds the running total with the count of users that existed before the window.
 

--- a/docs/guides/connect.md
+++ b/docs/guides/connect.md
@@ -1,0 +1,116 @@
+# Connect Your Tools
+
+Lumen exposes an **OpenAI-compatible API**, so most tools that speak to OpenAI can talk to Lumen by changing two things: the **base URL** and the **API key**.
+
+> **Tip:** The [Connect page](/connect) generates these snippets for you — including a ready-to-download OpenCode config listing every model your account can use, and curl/Python examples for a specific model. Log in first so it can fill in your models.
+
+## 1. Create an API key
+
+Create a key on your [Profile](/profile) page. Copy it when it is shown — it is only displayed once.
+
+## 2. Set the `LUMEN_API_KEY` environment variable
+
+Tools read the key from the environment rather than the config file, so the key never has to be written to disk.
+
+```
+export LUMEN_API_KEY="sk_…"      # macOS / Linux
+setx LUMEN_API_KEY "sk_…"        # Windows (applies to new terminals)
+```
+
+The base URL is your Lumen host with `/v1` appended, for example `https://lumen.example.com/v1`.
+
+## OpenCode
+
+[OpenCode](https://opencode.ai) reads the key from `{env:LUMEN_API_KEY}`. Use the **Download config.json** button on the [Connect page](/connect) to get a file pre-filled with every model you can access, then save it as:
+
+- **macOS / Linux:** `~/.config/opencode/opencode.json`
+- **Windows:** `%USERPROFILE%\.config\opencode\opencode.json`
+- Or `opencode.json` in a project's root directory for per-project settings.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "lumen": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Lumen",
+      "options": {
+        "baseURL": "https://lumen.example.com/v1",
+        "apiKey": "{env:LUMEN_API_KEY}"
+      },
+      "models": {
+        "MODEL": { "name": "MODEL via Lumen" }
+      }
+    }
+  }
+}
+```
+
+## curl
+
+Replace `MODEL` with a model id from the [Model Dashboard](/models).
+
+```
+curl https://lumen.example.com/v1/chat/completions \
+  -H "Authorization: Bearer $LUMEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "MODEL", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+## Python
+
+Use the official `openai` package pointed at the Lumen base URL.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://lumen.example.com/v1",
+    api_key=os.environ["LUMEN_API_KEY"],
+)
+
+resp = client.chat.completions.create(
+    model="MODEL",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(resp.choices[0].message.content)
+```
+
+## Images and audio
+
+Models that accept images take standard OpenAI `image_url` content blocks in a chat request.
+
+Audio models accept audio as `input_audio` content in a chat request. Some speech models require an audio placeholder token in the text so the model knows where the audio belongs — for example IBM granite-speech uses `<|audio|>`, followed by your instruction. Check the model's card for the exact token.
+
+Base64-encoded audio is too large to pass as an inline `-d` argument, so build the request body in a file and post it with `-d @file`:
+
+```
+# 1) Build the request body, embedding the base64-encoded audio
+cat > chat.json << EOF
+{
+  "model": "MODEL",
+  "messages": [{"role": "user", "content": [
+    {"type": "text", "text": "<|audio|> can you transcribe the speech into a written format?"},
+    {"type": "input_audio", "input_audio": {"data": "$(base64 < audio.mp3 | tr -d '\n')", "format": "mp3"}}
+  ]}]
+}
+EOF
+
+# 2) Send it
+curl https://lumen.example.com/v1/chat/completions \
+  -H "Authorization: Bearer $LUMEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @chat.json
+```
+
+Speech-to-text models can also be used through the transcription endpoint:
+
+```
+curl https://lumen.example.com/v1/audio/transcriptions \
+  -H "Authorization: Bearer $LUMEN_API_KEY" \
+  -F file=@audio.mp3 \
+  -F model=MODEL
+```
+
+Select a specific image- or audio-capable model on the [Connect page](/connect) to see tailored examples.

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -11,6 +11,7 @@
     "items": [
       {"slug": "chat",  "title": "Chat",             "filename": "chat.md"},
       {"slug": "profile", "title": "Profile & API Keys",  "filename": "profile.md"},
+      {"slug": "connect", "title": "Connect Your Tools",  "filename": "connect.md"},
       {"slug": "usage", "title": "Usage",            "filename": "usage.md"},
       {"slug": "api",   "title": "API Reference",     "filename": "api-reference.md"}
     ]

--- a/lumen/__init__.py
+++ b/lumen/__init__.py
@@ -259,6 +259,7 @@ def create_app():
     from lumen.blueprints.admin.routes import admin_bp
     from lumen.blueprints.metrics.routes import metrics_bp
     from lumen.blueprints.help.routes import help_bp
+    from lumen.blueprints.connect.routes import connect_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(chat_bp)
@@ -270,6 +271,7 @@ def create_app():
     app.register_blueprint(admin_bp)
     app.register_blueprint(metrics_bp)
     app.register_blueprint(help_bp)
+    app.register_blueprint(connect_bp)
 
     @app.route("/healthz")
     def healthz():

--- a/lumen/blueprints/connect/routes.py
+++ b/lumen/blueprints/connect/routes.py
@@ -1,0 +1,54 @@
+import re
+
+from flask import Blueprint, current_app, render_template, request, session
+from sqlalchemy import select
+
+from lumen.extensions import db
+from lumen.models.model_config import ModelConfig
+from lumen.services.llm import bulk_model_access_info
+
+connect_bp = Blueprint("connect", __name__)
+
+
+def _accessible_models(entity_id):
+    """Return active models the entity may use, as serialisable dicts.
+
+    Mirrors the access filtering on the models dashboard (active configs minus
+    those the entity is blocked from). Returns [] when not logged in.
+    """
+    if not entity_id:
+        return []
+    configs = db.session.execute(
+        select(ModelConfig).where(ModelConfig.active).order_by(ModelConfig.model_name)
+    ).scalars().all()
+    statuses, _ = bulk_model_access_info(entity_id, [c.id for c in configs])
+    return [
+        {
+            "id": c.model_name,
+            "name": c.model_name,
+            "input_modalities": c.input_modalities or [],
+            "output_modalities": c.output_modalities or [],
+        }
+        for c in configs
+        if statuses.get(c.id, "allowed") != "blocked"
+    ]
+
+
+@connect_bp.route("/connect")
+def index():
+    models = _accessible_models(session.get("entity_id"))
+
+    requested = request.args.get("model")
+    selected = requested if any(m["id"] == requested for m in models) else ""
+
+    app_name = current_app.config["APP_NAME"]
+    provider = re.sub(r"[^a-z0-9]", "", app_name.lower()) or "lumen"
+
+    return render_template(
+        "connect.html",
+        models=models,
+        selected_model=selected,
+        base_url=request.url_root.rstrip("/") + "/v1",
+        provider=provider,
+        provider_name=app_name,
+    )

--- a/lumen/static/js/connect.js
+++ b/lumen/static/js/connect.js
@@ -1,0 +1,248 @@
+// Builds OpenCode / curl / Python connection snippets for the /connect page.
+// Reads server data from #connect-data; the OpenCode config always covers every
+// accessible model, while the curl/Python examples follow the model selector and
+// adapt to the selected model's modalities (image / audio).
+(function () {
+  const dataEl = document.getElementById("connect-data");
+  if (!dataEl) return;
+  const data = JSON.parse(dataEl.textContent);
+  const BASE = data.base_url;
+  const PLACEHOLDER = "MODEL";
+
+  const select = document.getElementById("connect-model");
+
+  function modelById(id) {
+    return data.models.find((m) => m.id === id) || null;
+  }
+
+  // ── snippet block factory ────────────────────────────────────────────────
+  function block(title, code, extraButtons, note) {
+    const wrap = document.createElement("div");
+    wrap.className = "snippet mb-3";
+
+    const head = document.createElement("div");
+    head.className = "d-flex justify-content-between align-items-center mb-1 gap-2";
+    const label = document.createElement("span");
+    label.className = "fw-semibold";
+    label.textContent = title;
+    head.appendChild(label);
+
+    const btns = document.createElement("div");
+    btns.className = "d-flex gap-2";
+    (extraButtons || []).forEach((b) => btns.appendChild(b));
+
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.className = "btn btn-sm btn-outline-secondary";
+    copyBtn.textContent = "Copy";
+    copyBtn.setAttribute("aria-label", "Copy " + title + " to clipboard");
+    copyBtn.addEventListener("click", () => {
+      navigator.clipboard.writeText(code).then(() => {
+        copyBtn.textContent = "Copied!";
+        setTimeout(() => { copyBtn.textContent = "Copy"; }, 2000);
+      });
+    });
+    btns.appendChild(copyBtn);
+    head.appendChild(btns);
+
+    const pre = document.createElement("pre");
+    pre.className = "border rounded p-2 bg-light mb-0";
+    pre.style.overflow = "auto";
+    const codeEl = document.createElement("code");
+    codeEl.textContent = code;
+    pre.appendChild(codeEl);
+
+    wrap.appendChild(head);
+    wrap.appendChild(pre);
+    if (note) {
+      const n = document.createElement("p");
+      n.className = "text-muted small mt-1 mb-0";
+      n.textContent = note;
+      wrap.appendChild(n);
+    }
+    return wrap;
+  }
+
+  // ── OpenCode (always every accessible model) ─────────────────────────────
+  function openCodeConfig() {
+    const models = {};
+    if (data.models.length) {
+      data.models.forEach((m) => { models[m.id] = { name: m.name + " via " + data.provider_name }; });
+    } else {
+      models[PLACEHOLDER] = { name: "Model via " + data.provider_name };
+    }
+    return {
+      "$schema": "https://opencode.ai/config.json",
+      provider: {
+        [data.provider]: {
+          npm: "@ai-sdk/openai-compatible",
+          name: data.provider_name,
+          options: { baseURL: BASE, apiKey: "{env:LUMEN_API_KEY}" },
+          models: models,
+        },
+      },
+    };
+  }
+
+  function renderOpenCode() {
+    const container = document.getElementById("examples-opencode");
+    container.innerHTML = "";
+    const json = JSON.stringify(openCodeConfig(), null, 2);
+
+    const download = document.createElement("button");
+    download.type = "button";
+    download.className = "btn btn-sm btn-primary";
+    download.textContent = "Download config.json";
+    download.setAttribute("aria-label", "Download opencode.json");
+    download.addEventListener("click", () => {
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "opencode.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+
+    container.appendChild(block("opencode.json", json, [download]));
+  }
+
+  // ── curl ─────────────────────────────────────────────────────────────────
+  function curlText(id) {
+    return "curl " + BASE + "/chat/completions \\\n" +
+      '  -H "Authorization: Bearer $LUMEN_API_KEY" \\\n' +
+      '  -H "Content-Type: application/json" \\\n' +
+      "  -d '{\n" +
+      '    "model": "' + id + '",\n' +
+      '    "messages": [{"role": "user", "content": "Hello!"}]\n' +
+      "  }'";
+  }
+  function curlVision(id) {
+    return "curl " + BASE + "/chat/completions \\\n" +
+      '  -H "Authorization: Bearer $LUMEN_API_KEY" \\\n' +
+      '  -H "Content-Type: application/json" \\\n' +
+      "  -d '{\n" +
+      '    "model": "' + id + '",\n' +
+      '    "messages": [{"role": "user", "content": [\n' +
+      '      {"type": "text", "text": "What is in this image?"},\n' +
+      '      {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}}\n' +
+      "    ]}]\n  }'";
+  }
+  function curlAudioChat(id) {
+    // Base64 audio is too large for an inline -d argument, so build the request
+    // body in a file (embedding the audio) and post it with -d @file.
+    return "# 1) Build the request body, embedding the base64-encoded audio\n" +
+      "cat > chat.json << EOF\n" +
+      "{\n" +
+      '  "model": "' + id + '",\n' +
+      '  "messages": [{"role": "user", "content": [\n' +
+      '    {"type": "text", "text": "<|audio|> can you transcribe the speech into a written format?"},\n' +
+      "    {\"type\": \"input_audio\", \"input_audio\": {\"data\": \"$(base64 < audio.mp3 | tr -d '\\n')\", \"format\": \"mp3\"}}\n" +
+      "  ]}]\n" +
+      "}\n" +
+      "EOF\n\n" +
+      "# 2) Send it\n" +
+      "curl " + BASE + "/chat/completions \\\n" +
+      '  -H "Authorization: Bearer $LUMEN_API_KEY" \\\n' +
+      '  -H "Content-Type: application/json" \\\n' +
+      "  -d @chat.json";
+  }
+  function curlTranscribe(id) {
+    return "curl " + BASE + "/audio/transcriptions \\\n" +
+      '  -H "Authorization: Bearer $LUMEN_API_KEY" \\\n' +
+      "  -F file=@audio.mp3 \\\n" +
+      "  -F model=" + id;
+  }
+
+  // ── Python ─────────────────────────────────────────────────────────────────
+  const PY_SETUP =
+    "import os\n" +
+    "from openai import OpenAI\n\n" +
+    "client = OpenAI(\n" +
+    '    base_url="' + BASE + '",\n' +
+    '    api_key=os.environ["LUMEN_API_KEY"],\n' +
+    ")\n";
+  function pyText(id) {
+    return PY_SETUP + "\n" +
+      "resp = client.chat.completions.create(\n" +
+      '    model="' + id + '",\n' +
+      '    messages=[{"role": "user", "content": "Hello!"}],\n' +
+      ")\n" +
+      "print(resp.choices[0].message.content)";
+  }
+  function pyVision(id) {
+    return PY_SETUP + "\n" +
+      "resp = client.chat.completions.create(\n" +
+      '    model="' + id + '",\n' +
+      '    messages=[{"role": "user", "content": [\n' +
+      '        {"type": "text", "text": "What is in this image?"},\n' +
+      '        {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}},\n' +
+      "    ]}],\n)\n" +
+      "print(resp.choices[0].message.content)";
+  }
+  function pyAudioChat(id) {
+    return "import base64\n" + PY_SETUP + "\n" +
+      'with open("audio.mp3", "rb") as f:\n' +
+      "    audio_b64 = base64.b64encode(f.read()).decode()\n\n" +
+      "resp = client.chat.completions.create(\n" +
+      '    model="' + id + '",\n' +
+      '    messages=[{"role": "user", "content": [\n' +
+      '        {"type": "text", "text": "<|audio|> can you transcribe the speech into a written format?"},\n' +
+      '        {"type": "input_audio", "input_audio": {"data": audio_b64, "format": "mp3"}},\n' +
+      "    ]}],\n)\n" +
+      "print(resp.choices[0].message.content)";
+  }
+  function pyTranscribe(id) {
+    return PY_SETUP + "\n" +
+      'with open("audio.mp3", "rb") as f:\n' +
+      "    result = client.audio.transcriptions.create(\n" +
+      '        model="' + id + '", file=f,\n' +
+      "    )\n" +
+      "print(result.text)";
+  }
+
+  function render() {
+    renderOpenCode();
+
+    const sel = select ? select.value : "";
+    const model = sel ? modelById(sel) : null;
+    const id = model ? model.id : PLACEHOLDER;
+    const input = (model && model.input_modalities) || [];
+    const generic = !model;
+    const hasText = input.indexOf("text") !== -1;
+    const hasImage = input.indexOf("image") !== -1;
+    const hasAudio = input.indexOf("audio") !== -1;
+    // Audio-only models are speech models (e.g. granite-speech); they have no
+    // text input so the plain text-chat example is not meaningful for them, but
+    // they work through both the transcription endpoint and chat/completions.
+    const audioOnly = hasAudio && !hasText;
+    const AUDIO_NOTE = "Some audio models require an audio placeholder token in the text — granite-speech uses " +
+      "<|audio|>. Check the model's card for the exact token.";
+
+    const curl = document.getElementById("examples-curl");
+    const py = document.getElementById("examples-python");
+    curl.innerHTML = "";
+    py.innerHTML = "";
+
+    if (generic || hasText) {
+      curl.appendChild(block("Chat completion", curlText(id)));
+      py.appendChild(block("Chat completion", pyText(id)));
+    }
+    if (hasImage) {
+      curl.appendChild(block("Vision (image input)", curlVision(id)));
+      py.appendChild(block("Vision (image input)", pyVision(id)));
+    }
+    if (hasAudio) {
+      curl.appendChild(block("Audio in chat", curlAudioChat(id), null, AUDIO_NOTE));
+      py.appendChild(block("Audio in chat", pyAudioChat(id), null, AUDIO_NOTE));
+    }
+    // The transcription endpoint is for speech-to-text (audio-only) models.
+    if (audioOnly) {
+      curl.appendChild(block("Audio transcription", curlTranscribe(id)));
+      py.appendChild(block("Audio transcription", pyTranscribe(id)));
+    }
+  }
+
+  if (select) select.addEventListener("change", render);
+  render();
+})();

--- a/lumen/templates/client_detail.html
+++ b/lumen/templates/client_detail.html
@@ -137,8 +137,11 @@
 <!-- API Keys -->
 <div class="d-flex justify-content-between align-items-center mt-4 mb-0">
   <h2 class="mb-0">API Keys</h2>
-  <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#apiKeyModal"
-          aria-haspopup="dialog">+ New API Key</button>
+  <div class="d-flex gap-2">
+    <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('connect.index') }}">Usage examples</a>
+    <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#apiKeyModal"
+            aria-haspopup="dialog">+ New API Key</button>
+  </div>
 </div>
 <div class="d-flex justify-content-between align-items-center mt-2 mb-1">
   <div class="d-flex align-items-center gap-1">

--- a/lumen/templates/connect.html
+++ b/lumen/templates/connect.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+{% block title %}Connect your tools — {{ app_name }}{% endblock %}
+
+{% block content %}
+<ilw-content>
+  <h1>Connect your tools to {{ app_name }}</h1>
+
+  <p>
+    {{ app_name }} exposes an OpenAI-compatible API at
+    <code>{{ base_url }}</code>. Create an API key on your
+    <a href="{{ url_for('profile.index') }}">profile</a>, then make it available to your tools as the
+    <code>LUMEN_API_KEY</code> environment variable:
+  </p>
+  <pre class="border rounded p-2 bg-light"><code>export LUMEN_API_KEY="sk_…"      # macOS / Linux
+setx LUMEN_API_KEY "sk_…"        # Windows (new terminals)</code></pre>
+
+  {% if not models %}
+  <div class="alert alert-info" role="alert">
+    The examples below use a generic <code>MODEL</code> placeholder.
+    <a href="{{ url_for('auth.login') }}">Log in</a> to fill them in with the models you can access.
+  </div>
+  {% endif %}
+
+  <div class="row g-2 align-items-end mb-3" style="max-width:32rem">
+    <div class="col">
+      <label class="form-label mb-1" for="connect-model">Model (for the curl &amp; Python examples)</label>
+      <select id="connect-model" class="form-select">
+        <option value="">All models</option>
+        {% for m in models %}
+        <option value="{{ m.id }}" {% if m.id == selected_model %}selected{% endif %}>{{ m.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="tab-opencode" data-bs-toggle="tab" data-bs-target="#pane-opencode"
+              type="button" role="tab" aria-controls="pane-opencode" aria-selected="true">OpenCode</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="tab-curl" data-bs-toggle="tab" data-bs-target="#pane-curl"
+              type="button" role="tab" aria-controls="pane-curl" aria-selected="false">curl</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="tab-python" data-bs-toggle="tab" data-bs-target="#pane-python"
+              type="button" role="tab" aria-controls="pane-python" aria-selected="false">Python</button>
+    </li>
+  </ul>
+
+  <div class="tab-content border border-top-0 rounded-bottom p-3">
+
+    <div class="tab-pane fade show active" id="pane-opencode" role="tabpanel" aria-labelledby="tab-opencode">
+      <p class="text-muted small mb-2">
+        Configured with every model you can access. Uses <code>{env:LUMEN_API_KEY}</code> for the key.
+      </p>
+      <div id="examples-opencode"></div>
+      <div class="alert alert-secondary small mt-2 mb-0" role="note">
+        <strong>Where to put this file:</strong>
+        <ul class="mb-0">
+          <li><strong>macOS / Linux:</strong> <code>~/.config/opencode/opencode.json</code></li>
+          <li><strong>Windows:</strong> <code>%USERPROFILE%\.config\opencode\opencode.json</code></li>
+          <li>Or save <code>opencode.json</code> in a project's root directory for per-project settings.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="tab-pane fade" id="pane-curl" role="tabpanel" aria-labelledby="tab-curl">
+      <div id="examples-curl"></div>
+    </div>
+
+    <div class="tab-pane fade" id="pane-python" role="tabpanel" aria-labelledby="tab-python">
+      <div id="examples-python"></div>
+    </div>
+
+  </div>
+
+  <p class="mt-3"><a href="{{ url_for('help_bp.page', slug='connect') }}">Read the Connect guide</a> for more detail.</p>
+
+  <script type="application/json" id="connect-data">
+    {{ {"base_url": base_url, "provider": provider, "provider_name": provider_name,
+        "models": models, "selected": selected_model} | tojson }}
+  </script>
+</ilw-content>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/connect.js') }}"></script>
+{% endblock %}

--- a/lumen/templates/model_detail.html
+++ b/lumen/templates/model_detail.html
@@ -40,6 +40,10 @@
     {# ── Right sidebar ── #}
     <div class="col-12 col-lg-4 d-flex flex-column gap-3">
 
+      {% if access_status != 'blocked' %}
+      <a class="btn btn-primary" href="{{ url_for('connect.index', model=config.model_name) }}">Use this model</a>
+      {% endif %}
+
       {% if effective_notice %}
       <div class="alert alert-warning mb-0" role="alert" aria-live="polite">
         <strong>Notice</strong>

--- a/lumen/templates/models.html
+++ b/lumen/templates/models.html
@@ -2,7 +2,10 @@
 {% block title %}Models — {{ app_name }}{% endblock %}
 
 {% block content %}
-<h1>Model Dashboard</h1>
+<div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+  <h1 class="mb-0">Model Dashboard</h1>
+  <a class="btn btn-primary" href="{{ url_for('connect.index') }}">Connect your tools</a>
+</div>
 <ilw-content>
 
 <table class="table table-bordered table-hover align-middle">

--- a/lumen/templates/profile.html
+++ b/lumen/templates/profile.html
@@ -131,8 +131,11 @@
 <div class="d-flex justify-content-between align-items-center mt-4 mb-0">
   <h2 class="mb-0">API Keys</h2>
   {% if not viewing_user %}
-  <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#apiKeyModal"
-          aria-haspopup="dialog">+ New API Key</button>
+  <div class="d-flex gap-2">
+    <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('connect.index') }}">Usage examples</a>
+    <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#apiKeyModal"
+            aria-haspopup="dialog">+ New API Key</button>
+  </div>
   {% endif %}
 </div>
 <div class="d-flex justify-content-between align-items-center mt-2 mb-1">

--- a/tests/routes/test_connect_routes.py
+++ b/tests/routes/test_connect_routes.py
@@ -1,0 +1,53 @@
+import json
+from http import HTTPStatus
+
+from bs4 import BeautifulSoup
+
+
+def _connect_data(html_bytes):
+    soup = BeautifulSoup(html_bytes, "html.parser")
+    return json.loads(soup.find("script", id="connect-data").string)
+
+
+def test_connect_logged_out_is_generic(client):
+    resp = client.get("/connect")
+    assert resp.status_code == HTTPStatus.OK
+    data = _connect_data(resp.data)
+    assert data["models"] == []
+    assert data["selected"] == ""
+    assert data["base_url"].endswith("/v1")
+    # generic placeholder advertised in the body
+    assert b"MODEL" in resp.data
+
+
+def test_connect_lists_accessible_model(auth_client, test_model):
+    resp = auth_client.get("/connect")
+    assert resp.status_code == HTTPStatus.OK
+    ids = [m["id"] for m in _connect_data(resp.data)["models"]]
+    assert test_model["model_name"] in ids
+
+
+def test_connect_excludes_blocked_model(app, auth_client, test_model, test_user):
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity_model_access import EntityModelAccess
+        db.session.add(EntityModelAccess(
+            entity_id=test_user["id"],
+            model_config_id=test_model["id"],
+            access_type="blocked",
+        ))
+        db.session.commit()
+
+    resp = auth_client.get("/connect")
+    ids = [m["id"] for m in _connect_data(resp.data)["models"]]
+    assert test_model["model_name"] not in ids
+
+
+def test_connect_preselects_valid_model(auth_client, test_model):
+    resp = auth_client.get("/connect", query_string={"model": test_model["model_name"]})
+    assert _connect_data(resp.data)["selected"] == test_model["model_name"]
+
+
+def test_connect_ignores_unknown_model(auth_client, test_model):
+    resp = auth_client.get("/connect", query_string={"model": "does-not-exist"})
+    assert _connect_data(resp.data)["selected"] == ""

--- a/tests/ui/test_accessibility.py
+++ b/tests/ui/test_accessibility.py
@@ -137,6 +137,18 @@ def test_models_page(auth_client):
     _run_all_checks(resp.data, "/models")
 
 
+def test_connect_page_logged_out(client):
+    resp = client.get("/connect")
+    assert resp.status_code == HTTPStatus.OK
+    _run_all_checks(resp.data, "/connect")
+
+
+def test_connect_page_logged_in(auth_client, test_model):
+    resp = auth_client.get("/connect")
+    assert resp.status_code == HTTPStatus.OK
+    _run_all_checks(resp.data, "/connect")
+
+
 def test_admin_users_page(admin_client):
     resp = admin_client.get("/admin/users")
     assert resp.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Summary

Closes #18. Adds a linkable, tabbed **`/connect`** page that generates ready-to-use client configuration for talking to Lumen's OpenAI-compatible API, reusable from several places in the app.

- **OpenCode** — always lists every model the account can access; downloadable `opencode.json` keyed off the `LUMEN_API_KEY` environment variable (the config from the issue), with per-OS placement notes.
- **curl** and **Python (OpenAI SDK)** — copy-paste examples driven by a model selector. Picking a specific model tailors the snippets:
  - **vision** (`image_url`) example for image-capable models;
  - **audio-in-chat** example (including the model's `<|audio|>` placeholder token, e.g. granite-speech) plus a **`/v1/audio/transcriptions`** example for audio-capable models.
  - The audio-in-chat curl uses a **two-step "build a file, then `-d @file`"** pattern so large base64 audio doesn't exceed the shell's argument-length limit; the Python example reads/encodes the file directly.

The page is **public** but personalizes to the user's accessible models when logged in (blocked models excluded), and falls back to a generic `MODEL` placeholder when logged out. Snippets only ever reference the `LUMEN_API_KEY` env var — the real key is never injected.

**Entry points:** "Connect your tools" on the Models dashboard, "Use this model" on each model detail page (pre-selects via `?model=`), and "Usage examples" next to the New API Key button on the profile and client pages. Also documented in a new **Connect Your Tools** help guide.

Thanks to Josh Henry for the idea.

## Verification

- New route tests (`tests/routes/test_connect_routes.py`): logged-out generic mode, logged-in lists only accessible models, blocked-model exclusion, `?model=` pre-select.
- `/connect` added to the WCAG accessibility test suite (logged-out and logged-in).
- Full `uv run pytest` passes.
- Manually verified against the live dev stack: OpenCode download, model-tailored curl/Python, and both granite-speech audio paths (chat with `<|audio|>` and transcription) return `200` with correct output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)