### PR TITLE
Fix CheckViolation in client→project migration

### DIFF
--- a/migrations/versions/c4d5e6f7a8b9_rename_client_to_project.py
+++ b/migrations/versions/c4d5e6f7a8b9_rename_client_to_project.py
@@ -59,9 +59,10 @@ def upgrade():
     op.create_index("ix_entity_managers_project_entity_id", "entity_managers", ["project_entity_id"])
 
     # 3. Migrate the discriminator value and its CHECK constraint (PostgreSQL
-    #    raw SQL, matching b2c3d4e5f6g7).
-    op.execute("UPDATE entities SET entity_type = 'project' WHERE entity_type = 'client'")
+    #    raw SQL, matching b2c3d4e5f6g7). Drop the old CHECK before the UPDATE
+    #    so the new value is not rejected; re-add with the new value set.
     op.execute("ALTER TABLE entities DROP CONSTRAINT ck_entities_type")
+    op.execute("UPDATE entities SET entity_type = 'project' WHERE entity_type = 'client'")
     op.execute("ALTER TABLE entities ADD CONSTRAINT ck_entities_type CHECK (entity_type IN ('user', 'project'))")
 
     # 4. Refresh schema comments (PostgreSQL only), matching v2w3x4y5z6a7.
@@ -88,12 +89,13 @@ def downgrade():
     op.execute("DROP INDEX IF EXISTS ix_entity_managers_project_entity_id")
     op.create_index("ix_entity_managers_client_entity_id", "entity_managers", ["client_entity_id"])
 
-    # 3. Revert the discriminator value BEFORE re-adding the old CHECK constraint,
-    #    because PostgreSQL validates CHECK against existing rows at ADD time.
+    # 3. Drop the CHECK constraint before reverting the discriminator value:
+    #    the UPDATE is validated against the current constraint, and PostgreSQL
+    #    also validates CHECK against existing rows at ADD time.
+    op.execute("ALTER TABLE entities DROP CONSTRAINT ck_entities_type")
     op.execute("UPDATE entities SET entity_type = 'client' WHERE entity_type = 'project'")
 
     # 4. Swap the CHECK constraint back to ('user', 'client').
-    op.execute("ALTER TABLE entities DROP CONSTRAINT ck_entities_type")
     op.execute("ALTER TABLE entities ADD CONSTRAINT ck_entities_type CHECK (entity_type IN ('user', 'client'))")
 
     # 5. Restore the old schema comments (PostgreSQL only) — last, because the


### PR DESCRIPTION
## Problem

`flask db upgrade` failed at migration `c4d5e6f7a8b9` (rename `client` → `project`) with:

```
psycopg2.errors.CheckViolation: new row for relation "entities" violates check constraint "ck_entities_type"
DETAIL:  Failing row contains (59, project, null, cs101, CS, null, t, 2026-05-12 23:26:58.588206+00, allowed).
[SQL: UPDATE entities SET entity_type = 'project' WHERE entity_type = 'client']
```

## Root cause

In `upgrade()`, the `UPDATE entities SET entity_type = 'project'` ran **before** the old `ck_entities_type` CHECK constraint was dropped. The constraint still only allowed `('user', 'client')`, so PostgreSQL rejected `'project'` on the UPDATE. The `downgrade()` had the symmetric ordering bug.

PostgreSQL validates CHECK constraints both on row UPDATE **and** at `ADD CONSTRAINT` time, so the constraint must be dropped first, the data updated, then the new constraint added.

## Fix

Reorder both `upgrade()` and `downgrade()`:

1. `ALTER TABLE entities DROP CONSTRAINT ck_entities_type`
2. `UPDATE entities SET entity_type = ...` (no constraint to violate)
3. `ALTER TABLE entities ADD CONSTRAINT ck_entities_type CHECK (...)` (data already matches)

This matches the precedent set by `b2c3d4e5f6g7`, which established the drop/update/add pattern for this constraint.

## Recovery for affected installs

The failed migration ran inside a transaction, so the DB is still at `b7c8d9e0f1a2`. Re-running `flask db upgrade` after this fix applies the migration cleanly.

## Verification

- `tests/unit/test_migrations.py` passes (single alembic head confirmed)
- `gitnexus_detect_changes`: low risk, 0 affected processes (migration script, not application code)