### PR TITLE
Sync model pricing and SGLang server-authoritative capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Lumen will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- The config editor's **Update**/**Update All** buttons (and the `sync_models.py` CLI) now sync model **pricing** from models.dev. The input/output cost is the average across every provider listing the same base model, excluding $0 listings (which are not real prices and would skew the average down). Averaging avoids picking the lowest/highest/first provider and gives a representative cost; on a trusted models.dev match it overwrites a stale or zero operator-set value the same way other fields are corrected.
+- Model sync now queries SGLang's `/get_server_info` first. Its `max_req_input_len` is the real per-request limit derived from the operator's `--context-length` and available KV cache — authoritative over `/v1/models`' `max_model_len`, which on SGLang reports the model's theoretical max rather than the configured window. When `/get_server_info` succeeds, `/v1/models` is skipped entirely.
+- SGLang's `is_embedding` and `enable_multimodal` flags are now treated as authoritative over models.dev for modalities: an embedding model gets `output_modalities=[]`; a server with multimodal disabled is vetoed to text-only input; a server with multimodal enabled ensures image is present. vLLM (which exposes no such flags) continues to use models.dev for modalities.
+
 ## [1.21.0] - 2026-07-05
 
 ### Fixed

--- a/lumen/services/model_sync.py
+++ b/lumen/services/model_sync.py
@@ -18,7 +18,7 @@ OBSOLETE_FIELDS = ["supports_vision"]
 
 _TTL = 600  # 10 minutes
 
-_cache: dict = {"data": None, "ts": 0.0}
+_cache: dict = {"data": None, "ts": 0.0, "index": {}}
 
 
 # ---------------------------------------------------------------------------
@@ -30,6 +30,7 @@ def get_modelsdev() -> list[dict]:
     if _cache["data"] is None or now - _cache["ts"] > _TTL:
         _cache["data"] = _fetch_modelsdev()
         _cache["ts"] = now
+        _cache["index"] = _build_price_index(_cache["data"])
     return _cache["data"] or []
 
 
@@ -58,23 +59,26 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
     # SGLang: /get_server_info is the authoritative source — it exposes
     # max_req_input_len (the real per-request limit from --context-length,
     # not the model's theoretical max), is_embedding, and enable_multimodal.
-    # A 200 means we hit SGLang and have everything; skip /v1/models entirely.
+    # A 200 means we hit SGLang. We capture the capability flags even when
+    # max_req_input_len is absent (e.g. embedding-only deployments) so they
+    # survive the fallback chain below.
+    sglang_flags: dict = {}
     try:
         r = requests.get(f"{base}/get_server_info", headers=headers, timeout=ENDPOINT_TIMEOUT)
         if r.ok:
             info = r.json()
+            sglang_flags = {
+                "backend": "sglang",
+                "is_embedding": bool(info.get("is_embedding")),
+                "enable_multimodal": info.get("enable_multimodal"),
+            }
             mrl = info.get("max_req_input_len")
             if mrl is not None:
-                return {
-                    "id": info.get("served_model_name") or "",
-                    "max_model_len": mrl,
-                    "is_embedding": bool(info.get("is_embedding")),
-                    "enable_multimodal": info.get("enable_multimodal"),
-                }
+                return {"id": info.get("served_model_name") or "", "max_model_len": mrl, **sglang_flags}
     except Exception:
         pass
 
-    # vLLM (or SGLang without /get_server_info): /v1/models gives id + max_model_len.
+    # vLLM (or SGLang without max_req_input_len): /v1/models gives id + max_model_len.
     model_id = None
     try:
         r = requests.get(f"{base}/models", headers=headers, timeout=ENDPOINT_TIMEOUT)
@@ -83,7 +87,7 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
             model_id = models[0].get("id")
             mml = models[0].get("max_model_len")
             if mml is not None:
-                return {"id": model_id or "", "max_model_len": mml}
+                return {"id": model_id or "", "max_model_len": mml, **sglang_flags}
     except Exception:
         pass
 
@@ -92,9 +96,14 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
         r = requests.get(f"{base}/get_model_info", headers=headers, timeout=ENDPOINT_TIMEOUT)
         info = r.json()
         if "context_length" in info:
-            return {"id": model_id or info.get("model_path", ""), "max_model_len": info["context_length"]}
+            return {"id": model_id or info.get("model_path", ""), "max_model_len": info["context_length"], **sglang_flags}
     except Exception:
         pass
+
+    # SGLang responded with capability flags but no context length anywhere —
+    # still return them so the modality override can fire.
+    if sglang_flags:
+        return {"id": model_id or "", "max_model_len": None, **sglang_flags}
 
     return None
 
@@ -168,7 +177,18 @@ def find_in_modelsdev(model_id: str, models: list[dict], config_name: str | None
 # Pricing (average across providers)
 # ---------------------------------------------------------------------------
 
-def _average_price(dev_match: dict, dev_models: list[dict]) -> tuple[float | None, float | None]:
+def _build_price_index(models: list[dict]) -> dict[str, list[dict]]:
+    """Group models.dev entries by normalized id, once, so _average_price is
+    an O(1) lookup instead of re-scanning the whole catalogue per model."""
+    idx: dict[str, list[dict]] = {}
+    for m in models:
+        nid = _normalize_id(m.get("id", ""))
+        if nid:
+            idx.setdefault(nid, []).append(m)
+    return idx
+
+
+def _average_price(dev_match: dict, price_index: dict[str, list[dict]]) -> tuple[float | None, float | None]:
     """Average input/output cost (USD per million tokens) across every
     models.dev provider that lists the same base model, ignoring zero/missing
     prices (a $0 listing is not a real price and would skew the average down).
@@ -181,9 +201,7 @@ def _average_price(dev_match: dict, dev_models: list[dict]) -> tuple[float | Non
         return None, None
     inputs: list[float] = []
     outputs: list[float] = []
-    for m in dev_models:
-        if _normalize_id(m.get("id", "")) != needle:
-            continue
+    for m in price_index.get(needle, []):
         c = m.get("cost") or {}
         try:
             ci = float(c.get("input") or 0)
@@ -200,6 +218,26 @@ def _average_price(dev_match: dict, dev_models: list[dict]) -> tuple[float | Non
 
 
 # ---------------------------------------------------------------------------
+# Server-authoritative modalities
+# ---------------------------------------------------------------------------
+
+def _server_modalities(ep_model: dict, pending_in, current_in) -> tuple:
+    """Return (srv_in, srv_out) from SGLang server capability flags.
+
+    Each component is the authoritative modality list, or None to mean
+    "don't touch this field". pending_in is the input_modalities already
+    proposed by models.dev (if any); current_in is the operator's current
+    value — used as the base to which image is added when multimodal is on.
+    """
+    if ep_model.get("is_embedding"):
+        return ["text"], []
+    if ep_model.get("enable_multimodal") is True:
+        base = pending_in or current_in or ["text"]
+        return (base if "image" in base else [*base, "image"]), None
+    return ["text"], None
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -213,6 +251,7 @@ def sync_model(model_def: dict) -> dict:
       endpoint_ok – whether at least one endpoint responded
     """
     dev_models = get_modelsdev()
+    price_index = _cache["index"]
 
     ep_model = None
     for ep in model_def.get("endpoints", []):
@@ -259,7 +298,7 @@ def sync_model(model_def: dict) -> dict:
         # Pricing: average across providers offering the same base model on
         # models.dev, excluding $0 listings. Overwrites a stale/zero operator
         # value the same way other fields are corrected on a trusted match.
-        avg_in, avg_out = _average_price(dev_match, dev_models)
+        avg_in, avg_out = _average_price(dev_match, price_index)
         if avg_in is not None and model_def.get("input_cost_per_million") != avg_in:
             updates["input_cost_per_million"] = avg_in
         if avg_out is not None and model_def.get("output_cost_per_million") != avg_out:
@@ -267,25 +306,23 @@ def sync_model(model_def: dict) -> dict:
 
     # SGLang /get_server_info capability flags are authoritative over models.dev
     # — they reflect what the operator actually enabled on the serving backend,
-    # so a disabled modality on the server vetoes a models.dev claim. (Only
-    # present when the endpoint was reached via /get_server_info.)
-    if ep_model and "enable_multimodal" in ep_model:
-        if ep_model.get("is_embedding"):
-            srv_in, srv_out = ["text"], []
-        elif ep_model.get("enable_multimodal") is True:
-            base = updates.get("input_modalities") or model_def.get("input_modalities") or ["text"]
-            srv_in = base if "image" in base else [*base, "image"]
-            srv_out = None
-        else:
-            srv_in, srv_out = ["text"], None
-
-        for field, srv in (("input_modalities", srv_in), ("output_modalities", srv_out)):
-            if srv is None:
-                continue
-            if model_def.get(field) != srv:
-                updates[field] = srv
-            elif field in updates:
-                del updates[field]
+    # so a disabled modality on the server vetoes a models.dev claim.
+    if ep_model and ep_model.get("backend") == "sglang":
+        srv_in, srv_out = _server_modalities(
+            ep_model,
+            updates.get("input_modalities"),
+            model_def.get("input_modalities"),
+        )
+        if srv_in is not None:
+            if model_def.get("input_modalities") != srv_in:
+                updates["input_modalities"] = srv_in
+            elif "input_modalities" in updates:
+                del updates["input_modalities"]
+        if srv_out is not None:
+            if model_def.get("output_modalities") != srv_out:
+                updates["output_modalities"] = srv_out
+            elif "output_modalities" in updates:
+                del updates["output_modalities"]
 
     removals = [f for f in OBSOLETE_FIELDS if f in model_def]
 

--- a/lumen/services/model_sync.py
+++ b/lumen/services/model_sync.py
@@ -25,13 +25,18 @@ _cache: dict = {"data": None, "ts": 0.0, "index": {}}
 # models.dev fetch + cache
 # ---------------------------------------------------------------------------
 
-def get_modelsdev() -> list[dict]:
+def get_modelsdev() -> tuple[list[dict], dict[str, list[dict]]]:
+    """Return a (models, price_index) snapshot from the TTL cache.
+
+    Both come from the same fetch so callers can't see a torn view if a
+    concurrent request refreshes the cache between two separate reads.
+    """
     now = time.monotonic()
     if _cache["data"] is None or now - _cache["ts"] > _TTL:
         _cache["data"] = _fetch_modelsdev()
         _cache["ts"] = now
         _cache["index"] = _build_price_index(_cache["data"])
-    return _cache["data"] or []
+    return _cache["data"] or [], _cache["index"]
 
 
 def _fetch_modelsdev() -> list[dict]:
@@ -250,8 +255,7 @@ def sync_model(model_def: dict) -> dict:
       matched   – models.dev model id that was matched, or None
       endpoint_ok – whether at least one endpoint responded
     """
-    dev_models = get_modelsdev()
-    price_index = _cache["index"]
+    dev_models, price_index = get_modelsdev()
 
     ep_model = None
     for ep in model_def.get("endpoints", []):

--- a/lumen/services/model_sync.py
+++ b/lumen/services/model_sync.py
@@ -64,22 +64,23 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
     # SGLang: /get_server_info is the authoritative source — it exposes
     # max_req_input_len (the real per-request limit from --context-length,
     # not the model's theoretical max), is_embedding, and enable_multimodal.
-    # A 200 means we hit SGLang. We capture the capability flags even when
-    # max_req_input_len is absent (e.g. embedding-only deployments) so they
-    # survive the fallback chain below.
+    # A 200 alone doesn't prove it's SGLang (a proxy/gateway in front of vLLM
+    # could return 200 for that path), so we only tag backend="sglang" when the
+    # body actually contains at least one SGLang-specific key we consume.
     sglang_flags: dict = {}
     try:
         r = requests.get(f"{base}/get_server_info", headers=headers, timeout=ENDPOINT_TIMEOUT)
         if r.ok:
             info = r.json()
-            sglang_flags = {
-                "backend": "sglang",
-                "is_embedding": bool(info.get("is_embedding")),
-                "enable_multimodal": info.get("enable_multimodal"),
-            }
-            mrl = info.get("max_req_input_len")
-            if mrl is not None:
-                return {"id": info.get("served_model_name") or "", "max_model_len": mrl, **sglang_flags}
+            if any(k in info for k in ("max_req_input_len", "is_embedding", "enable_multimodal")):
+                sglang_flags = {
+                    "backend": "sglang",
+                    "is_embedding": bool(info.get("is_embedding")),
+                    "enable_multimodal": info.get("enable_multimodal"),
+                }
+                mrl = info.get("max_req_input_len")
+                if mrl is not None:
+                    return {"id": info.get("served_model_name") or "", "max_model_len": mrl, **sglang_flags}
     except Exception:
         pass
 

--- a/lumen/services/model_sync.py
+++ b/lumen/services/model_sync.py
@@ -55,15 +55,39 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
     base = endpoint["url"].rstrip("/")
     headers = {"Authorization": f"Bearer {endpoint.get('api_key', '')}"}
 
+    # SGLang: /get_server_info is the authoritative source — it exposes
+    # max_req_input_len (the real per-request limit from --context-length,
+    # not the model's theoretical max), is_embedding, and enable_multimodal.
+    # A 200 means we hit SGLang and have everything; skip /v1/models entirely.
+    try:
+        r = requests.get(f"{base}/get_server_info", headers=headers, timeout=ENDPOINT_TIMEOUT)
+        if r.ok:
+            info = r.json()
+            mrl = info.get("max_req_input_len")
+            if mrl is not None:
+                return {
+                    "id": info.get("served_model_name") or "",
+                    "max_model_len": mrl,
+                    "is_embedding": bool(info.get("is_embedding")),
+                    "enable_multimodal": info.get("enable_multimodal"),
+                }
+    except Exception:
+        pass
+
+    # vLLM (or SGLang without /get_server_info): /v1/models gives id + max_model_len.
+    model_id = None
     try:
         r = requests.get(f"{base}/models", headers=headers, timeout=ENDPOINT_TIMEOUT)
         models = r.json().get("data", [])
-        if models and models[0].get("max_model_len") is not None:
-            return models[0]
-        model_id = models[0].get("id") if models else None
+        if models:
+            model_id = models[0].get("id")
+            mml = models[0].get("max_model_len")
+            if mml is not None:
+                return {"id": model_id or "", "max_model_len": mml}
     except Exception:
-        model_id = None
+        pass
 
+    # Older SGLang: /get_model_info returns context_length.
     try:
         r = requests.get(f"{base}/get_model_info", headers=headers, timeout=ENDPOINT_TIMEOUT)
         info = r.json()
@@ -141,6 +165,41 @@ def find_in_modelsdev(model_id: str, models: list[dict], config_name: str | None
 
 
 # ---------------------------------------------------------------------------
+# Pricing (average across providers)
+# ---------------------------------------------------------------------------
+
+def _average_price(dev_match: dict, dev_models: list[dict]) -> tuple[float | None, float | None]:
+    """Average input/output cost (USD per million tokens) across every
+    models.dev provider that lists the same base model, ignoring zero/missing
+    prices (a $0 listing is not a real price and would skew the average down).
+
+    Returns (input_avg, output_avg); each component is None when no provider
+    exposes a usable (>0) price for it.
+    """
+    needle = _normalize_id(dev_match.get("id", ""))
+    if not needle:
+        return None, None
+    inputs: list[float] = []
+    outputs: list[float] = []
+    for m in dev_models:
+        if _normalize_id(m.get("id", "")) != needle:
+            continue
+        c = m.get("cost") or {}
+        try:
+            ci = float(c.get("input") or 0)
+            co = float(c.get("output") or 0)
+        except (TypeError, ValueError):
+            continue
+        if ci > 0:
+            inputs.append(ci)
+        if co > 0:
+            outputs.append(co)
+    avg_in = round(sum(inputs) / len(inputs), 6) if inputs else None
+    avg_out = round(sum(outputs) / len(outputs), 6) if outputs else None
+    return avg_in, avg_out
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -196,6 +255,37 @@ def sync_model(model_def: dict) -> dict:
         ]:
             if new_val is not None and model_def.get(field) != new_val:
                 updates[field] = new_val
+
+        # Pricing: average across providers offering the same base model on
+        # models.dev, excluding $0 listings. Overwrites a stale/zero operator
+        # value the same way other fields are corrected on a trusted match.
+        avg_in, avg_out = _average_price(dev_match, dev_models)
+        if avg_in is not None and model_def.get("input_cost_per_million") != avg_in:
+            updates["input_cost_per_million"] = avg_in
+        if avg_out is not None and model_def.get("output_cost_per_million") != avg_out:
+            updates["output_cost_per_million"] = avg_out
+
+    # SGLang /get_server_info capability flags are authoritative over models.dev
+    # — they reflect what the operator actually enabled on the serving backend,
+    # so a disabled modality on the server vetoes a models.dev claim. (Only
+    # present when the endpoint was reached via /get_server_info.)
+    if ep_model and "enable_multimodal" in ep_model:
+        if ep_model.get("is_embedding"):
+            srv_in, srv_out = ["text"], []
+        elif ep_model.get("enable_multimodal") is True:
+            base = updates.get("input_modalities") or model_def.get("input_modalities") or ["text"]
+            srv_in = base if "image" in base else [*base, "image"]
+            srv_out = None
+        else:
+            srv_in, srv_out = ["text"], None
+
+        for field, srv in (("input_modalities", srv_in), ("output_modalities", srv_out)):
+            if srv is None:
+                continue
+            if model_def.get(field) != srv:
+                updates[field] = srv
+            elif field in updates:
+                del updates[field]
 
     removals = [f for f in OBSOLETE_FIELDS if f in model_def]
 

--- a/sync_models.py
+++ b/sync_models.py
@@ -51,22 +51,23 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
     # SGLang: /get_server_info is the authoritative source — it exposes
     # max_req_input_len (the real per-request limit from --context-length,
     # not the model's theoretical max), is_embedding, and enable_multimodal.
-    # A 200 means we hit SGLang. We capture the capability flags even when
-    # max_req_input_len is absent (e.g. embedding-only deployments) so they
-    # survive the fallback chain below.
+    # A 200 alone doesn't prove it's SGLang (a proxy/gateway in front of vLLM
+    # could return 200 for that path), so we only tag backend="sglang" when the
+    # body actually contains at least one SGLang-specific key we consume.
     sglang_flags: dict = {}
     try:
         r = requests.get(f"{base}/get_server_info", headers=headers, timeout=TIMEOUT)
         if r.ok:
             info = r.json()
-            sglang_flags = {
-                "backend": "sglang",
-                "is_embedding": bool(info.get("is_embedding")),
-                "enable_multimodal": info.get("enable_multimodal"),
-            }
-            mrl = info.get("max_req_input_len")
-            if mrl is not None:
-                return {"id": info.get("served_model_name") or "", "max_model_len": mrl, **sglang_flags}
+            if any(k in info for k in ("max_req_input_len", "is_embedding", "enable_multimodal")):
+                sglang_flags = {
+                    "backend": "sglang",
+                    "is_embedding": bool(info.get("is_embedding")),
+                    "enable_multimodal": info.get("enable_multimodal"),
+                }
+                mrl = info.get("max_req_input_len")
+                if mrl is not None:
+                    return {"id": info.get("served_model_name") or "", "max_model_len": mrl, **sglang_flags}
     except Exception:
         pass
 

--- a/sync_models.py
+++ b/sync_models.py
@@ -51,23 +51,26 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
     # SGLang: /get_server_info is the authoritative source — it exposes
     # max_req_input_len (the real per-request limit from --context-length,
     # not the model's theoretical max), is_embedding, and enable_multimodal.
-    # A 200 means we hit SGLang and have everything; skip /v1/models entirely.
+    # A 200 means we hit SGLang. We capture the capability flags even when
+    # max_req_input_len is absent (e.g. embedding-only deployments) so they
+    # survive the fallback chain below.
+    sglang_flags: dict = {}
     try:
         r = requests.get(f"{base}/get_server_info", headers=headers, timeout=TIMEOUT)
         if r.ok:
             info = r.json()
+            sglang_flags = {
+                "backend": "sglang",
+                "is_embedding": bool(info.get("is_embedding")),
+                "enable_multimodal": info.get("enable_multimodal"),
+            }
             mrl = info.get("max_req_input_len")
             if mrl is not None:
-                return {
-                    "id": info.get("served_model_name") or "",
-                    "max_model_len": mrl,
-                    "is_embedding": bool(info.get("is_embedding")),
-                    "enable_multimodal": info.get("enable_multimodal"),
-                }
+                return {"id": info.get("served_model_name") or "", "max_model_len": mrl, **sglang_flags}
     except Exception:
         pass
 
-    # vLLM (or SGLang without /get_server_info): /v1/models gives id + max_model_len.
+    # vLLM (or SGLang without max_req_input_len): /v1/models gives id + max_model_len.
     model_id = None
     try:
         r = requests.get(f"{base}/models", headers=headers, timeout=TIMEOUT)
@@ -76,7 +79,7 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
             model_id = models[0].get("id")
             mml = models[0].get("max_model_len")
             if mml is not None:
-                return {"id": model_id or "", "max_model_len": mml}
+                return {"id": model_id or "", "max_model_len": mml, **sglang_flags}
     except Exception:
         pass
 
@@ -85,9 +88,14 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
         r = requests.get(f"{base}/get_model_info", headers=headers, timeout=TIMEOUT)
         info = r.json()
         if "context_length" in info:
-            return {"id": model_id or info.get("model_path", ""), "max_model_len": info["context_length"]}
+            return {"id": model_id or info.get("model_path", ""), "max_model_len": info["context_length"], **sglang_flags}
     except Exception:
         pass
+
+    # SGLang responded with capability flags but no context length anywhere —
+    # still return them so the modality override can fire.
+    if sglang_flags:
+        return {"id": model_id or "", "max_model_len": None, **sglang_flags}
 
     return None
 
@@ -174,7 +182,18 @@ def find_in_modelsdev(model_id: str, models: list[dict], config_name: str | None
 # Pricing (average across providers)
 # ---------------------------------------------------------------------------
 
-def _average_price(dev_model: dict, dev_models: list[dict]) -> tuple[float | None, float | None]:
+def _build_price_index(models: list[dict]) -> dict[str, list[dict]]:
+    """Group models.dev entries by normalized id, once, so _average_price is
+    an O(1) lookup instead of re-scanning the whole catalogue per model."""
+    idx: dict[str, list[dict]] = {}
+    for m in models:
+        nid = _normalize_id(m.get("id", ""))
+        if nid:
+            idx.setdefault(nid, []).append(m)
+    return idx
+
+
+def _average_price(dev_model: dict, price_index: dict[str, list[dict]]) -> tuple[float | None, float | None]:
     """Average input/output cost (USD per million tokens) across every
     models.dev provider that lists the same base model, ignoring zero/missing
     prices (a $0 listing is not a real price and would skew the average down).
@@ -187,9 +206,7 @@ def _average_price(dev_model: dict, dev_models: list[dict]) -> tuple[float | Non
         return None, None
     inputs: list[float] = []
     outputs: list[float] = []
-    for m in dev_models:
-        if _normalize_id(m.get("id", "")) != needle:
-            continue
+    for m in price_index.get(needle, []):
         c = m.get("cost") or {}
         try:
             ci = float(c.get("input") or 0)
@@ -206,12 +223,32 @@ def _average_price(dev_model: dict, dev_models: list[dict]) -> tuple[float | Non
 
 
 # ---------------------------------------------------------------------------
+# Server-authoritative modalities
+# ---------------------------------------------------------------------------
+
+def _server_modalities(ep_model: dict, pending_in, current_in) -> tuple:
+    """Return (srv_in, srv_out) from SGLang server capability flags.
+
+    Each component is the authoritative modality list, or None to mean
+    "don't touch this field". pending_in is the input_modalities already
+    proposed by models.dev (if any); current_in is the operator's current
+    value — used as the base to which image is added when multimodal is on.
+    """
+    if ep_model.get("is_embedding"):
+        return ["text"], []
+    if ep_model.get("enable_multimodal") is True:
+        base = pending_in or current_in or ["text"]
+        return (base if "image" in base else [*base, "image"]), None
+    return ["text"], None
+
+
+# ---------------------------------------------------------------------------
 # Change computation
 # ---------------------------------------------------------------------------
 
 def compute_changes(
     model_def: dict, ep_model: dict | None, dev_model: dict | None,
-    dev_models: list[dict] | None = None,
+    price_index: dict[str, list[dict]] | None = None,
 ) -> tuple[dict, list[str]]:
     """Return (changes, removals) where changes maps field → (old, new) and
     removals is a list of obsolete field names present in model_def."""
@@ -237,8 +274,8 @@ def compute_changes(
         # Pricing: average across providers offering the same base model on
         # models.dev, excluding $0 listings. Overwrites a stale/zero operator
         # value the same way other fields are corrected on a trusted match.
-        if dev_models:
-            avg_in, avg_out = _average_price(dev_model, dev_models)
+        if price_index:
+            avg_in, avg_out = _average_price(dev_model, price_index)
             if avg_in is not None and model_def.get("input_cost_per_million") != avg_in:
                 changes["input_cost_per_million"] = (model_def.get("input_cost_per_million"), avg_in)
             if avg_out is not None and model_def.get("output_cost_per_million") != avg_out:
@@ -246,26 +283,24 @@ def compute_changes(
 
     # SGLang /get_server_info capability flags are authoritative over models.dev
     # — they reflect what the operator actually enabled on the serving backend,
-    # so a disabled modality on the server vetoes a models.dev claim. (Only
-    # present when the endpoint was reached via /get_server_info.)
-    if ep_model and "enable_multimodal" in ep_model:
-        if ep_model.get("is_embedding"):
-            srv_in, srv_out = ["text"], []
-        elif ep_model.get("enable_multimodal") is True:
-            dev_change = changes.get("input_modalities")
-            base = dev_change[1] if dev_change else (model_def.get("input_modalities") or ["text"])
-            srv_in = base if "image" in base else [*base, "image"]
-            srv_out = None
-        else:
-            srv_in, srv_out = ["text"], None
-
-        for field, srv in (("input_modalities", srv_in), ("output_modalities", srv_out)):
-            if srv is None:
-                continue
-            if model_def.get(field) != srv:
-                changes[field] = (model_def.get(field), srv)
-            elif field in changes:
-                del changes[field]
+    # so a disabled modality on the server vetoes a models.dev claim.
+    if ep_model and ep_model.get("backend") == "sglang":
+        pending = changes.get("input_modalities", (None, None))[1]
+        srv_in, srv_out = _server_modalities(
+            ep_model,
+            pending,
+            model_def.get("input_modalities"),
+        )
+        if srv_in is not None:
+            if model_def.get("input_modalities") != srv_in:
+                changes["input_modalities"] = (model_def.get("input_modalities"), srv_in)
+            elif "input_modalities" in changes:
+                del changes["input_modalities"]
+        if srv_out is not None:
+            if model_def.get("output_modalities") != srv_out:
+                changes["output_modalities"] = (model_def.get("output_modalities"), srv_out)
+            elif "output_modalities" in changes:
+                del changes["output_modalities"]
 
     removals = [f for f in OBSOLETE_FIELDS if f in model_def]
     return changes, removals
@@ -365,6 +400,7 @@ def main():
     print("Fetching models.dev ... ", end="", flush=True)
     dev_models = fetch_modelsdev()
     print(f"{len(dev_models)} models\n" if dev_models else "failed\n")
+    price_index = _build_price_index(dev_models) if dev_models else {}
 
     any_changes = False
 
@@ -396,7 +432,7 @@ def main():
                 if dev_model else "  models.dev: no match"
             )
 
-        changes, removals = compute_changes(model_def, ep_model, dev_model, dev_models)
+        changes, removals = compute_changes(model_def, ep_model, dev_model, price_index)
 
         if not changes and not removals:
             print("  No changes.\n")

--- a/sync_models.py
+++ b/sync_models.py
@@ -48,26 +48,44 @@ def fetch_endpoint_model(endpoint: dict) -> dict | None:
     base = endpoint["url"].rstrip("/")
     headers = {"Authorization": f"Bearer {endpoint['api_key']}"}
 
-    # vLLM: /v1/models returns max_model_len directly
+    # SGLang: /get_server_info is the authoritative source — it exposes
+    # max_req_input_len (the real per-request limit from --context-length,
+    # not the model's theoretical max), is_embedding, and enable_multimodal.
+    # A 200 means we hit SGLang and have everything; skip /v1/models entirely.
+    try:
+        r = requests.get(f"{base}/get_server_info", headers=headers, timeout=TIMEOUT)
+        if r.ok:
+            info = r.json()
+            mrl = info.get("max_req_input_len")
+            if mrl is not None:
+                return {
+                    "id": info.get("served_model_name") or "",
+                    "max_model_len": mrl,
+                    "is_embedding": bool(info.get("is_embedding")),
+                    "enable_multimodal": info.get("enable_multimodal"),
+                }
+    except Exception:
+        pass
+
+    # vLLM (or SGLang without /get_server_info): /v1/models gives id + max_model_len.
+    model_id = None
     try:
         r = requests.get(f"{base}/models", headers=headers, timeout=TIMEOUT)
         models = r.json().get("data", [])
-        if models and models[0].get("max_model_len") is not None:
-            return models[0]
-        # SGLang: /v1/models exists but lacks max_model_len — fall through
-        model_id = models[0].get("id") if models else None
+        if models:
+            model_id = models[0].get("id")
+            mml = models[0].get("max_model_len")
+            if mml is not None:
+                return {"id": model_id or "", "max_model_len": mml}
     except Exception:
-        model_id = None
+        pass
 
-    # SGLang: /get_model_info returns context_length
+    # Older SGLang: /get_model_info returns context_length.
     try:
         r = requests.get(f"{base}/get_model_info", headers=headers, timeout=TIMEOUT)
         info = r.json()
         if "context_length" in info:
-            return {
-                "id": model_id or info.get("model_path", ""),
-                "max_model_len": info["context_length"],
-            }
+            return {"id": model_id or info.get("model_path", ""), "max_model_len": info["context_length"]}
     except Exception:
         pass
 
@@ -153,11 +171,47 @@ def find_in_modelsdev(model_id: str, models: list[dict], config_name: str | None
 
 
 # ---------------------------------------------------------------------------
+# Pricing (average across providers)
+# ---------------------------------------------------------------------------
+
+def _average_price(dev_model: dict, dev_models: list[dict]) -> tuple[float | None, float | None]:
+    """Average input/output cost (USD per million tokens) across every
+    models.dev provider that lists the same base model, ignoring zero/missing
+    prices (a $0 listing is not a real price and would skew the average down).
+
+    Returns (input_avg, output_avg); each component is None when no provider
+    exposes a usable (>0) price for it.
+    """
+    needle = _normalize_id(dev_model.get("id", ""))
+    if not needle:
+        return None, None
+    inputs: list[float] = []
+    outputs: list[float] = []
+    for m in dev_models:
+        if _normalize_id(m.get("id", "")) != needle:
+            continue
+        c = m.get("cost") or {}
+        try:
+            ci = float(c.get("input") or 0)
+            co = float(c.get("output") or 0)
+        except (TypeError, ValueError):
+            continue
+        if ci > 0:
+            inputs.append(ci)
+        if co > 0:
+            outputs.append(co)
+    avg_in = round(sum(inputs) / len(inputs), 6) if inputs else None
+    avg_out = round(sum(outputs) / len(outputs), 6) if outputs else None
+    return avg_in, avg_out
+
+
+# ---------------------------------------------------------------------------
 # Change computation
 # ---------------------------------------------------------------------------
 
 def compute_changes(
-    model_def: dict, ep_model: dict | None, dev_model: dict | None
+    model_def: dict, ep_model: dict | None, dev_model: dict | None,
+    dev_models: list[dict] | None = None,
 ) -> tuple[dict, list[str]]:
     """Return (changes, removals) where changes maps field → (old, new) and
     removals is a list of obsolete field names present in model_def."""
@@ -179,6 +233,39 @@ def compute_changes(
         ]:
             if new_val is not None and model_def.get(field) != new_val:
                 changes[field] = (model_def.get(field), new_val)
+
+        # Pricing: average across providers offering the same base model on
+        # models.dev, excluding $0 listings. Overwrites a stale/zero operator
+        # value the same way other fields are corrected on a trusted match.
+        if dev_models:
+            avg_in, avg_out = _average_price(dev_model, dev_models)
+            if avg_in is not None and model_def.get("input_cost_per_million") != avg_in:
+                changes["input_cost_per_million"] = (model_def.get("input_cost_per_million"), avg_in)
+            if avg_out is not None and model_def.get("output_cost_per_million") != avg_out:
+                changes["output_cost_per_million"] = (model_def.get("output_cost_per_million"), avg_out)
+
+    # SGLang /get_server_info capability flags are authoritative over models.dev
+    # — they reflect what the operator actually enabled on the serving backend,
+    # so a disabled modality on the server vetoes a models.dev claim. (Only
+    # present when the endpoint was reached via /get_server_info.)
+    if ep_model and "enable_multimodal" in ep_model:
+        if ep_model.get("is_embedding"):
+            srv_in, srv_out = ["text"], []
+        elif ep_model.get("enable_multimodal") is True:
+            dev_change = changes.get("input_modalities")
+            base = dev_change[1] if dev_change else (model_def.get("input_modalities") or ["text"])
+            srv_in = base if "image" in base else [*base, "image"]
+            srv_out = None
+        else:
+            srv_in, srv_out = ["text"], None
+
+        for field, srv in (("input_modalities", srv_in), ("output_modalities", srv_out)):
+            if srv is None:
+                continue
+            if model_def.get(field) != srv:
+                changes[field] = (model_def.get(field), srv)
+            elif field in changes:
+                del changes[field]
 
     removals = [f for f in OBSOLETE_FIELDS if f in model_def]
     return changes, removals
@@ -309,7 +396,7 @@ def main():
                 if dev_model else "  models.dev: no match"
             )
 
-        changes, removals = compute_changes(model_def, ep_model, dev_model)
+        changes, removals = compute_changes(model_def, ep_model, dev_model, dev_models)
 
         if not changes and not removals:
             print("  No changes.\n")

--- a/tests/unit/test_model_sync.py
+++ b/tests/unit/test_model_sync.py
@@ -261,6 +261,22 @@ def test_vllm_used_when_server_info_absent(monkeypatch):
     assert "backend" not in r  # vLLM path: no sglang flags
 
 
+def test_proxy_200_empty_body_not_tagged_sglang(monkeypatch):
+    """A proxy/gateway in front of vLLM that returns 200 {} for /get_server_info
+    must not be tagged backend="sglang" — that would trigger the text-only veto
+    on a real multimodal vLLM server behind it."""
+    def fake_get(url, **kw):
+        if url.endswith("/get_server_info"):
+            return _Resp({})  # 200 but empty — not SGLang
+        if url.endswith("/models"):
+            return _Resp({"data": [{"id": "m", "max_model_len": 32768}]})
+        return _Resp({}, ok=False)
+    monkeypatch.setattr(model_sync.requests, "get", fake_get)
+    r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
+    assert "backend" not in r  # must fall through to vLLM path
+    assert r["max_model_len"] == 32768
+
+
 def test_get_model_info_fallback(monkeypatch):
     """Older SGLang with neither /get_server_info nor /v1/models max_model_len
     → /get_model_info context_length is used."""

--- a/tests/unit/test_model_sync.py
+++ b/tests/unit/test_model_sync.py
@@ -4,7 +4,7 @@ from lumen.services import model_sync
 
 def _patch(monkeypatch, ep_model, dev_match):
     monkeypatch.setattr(model_sync, "fetch_endpoint_model", lambda ep: ep_model)
-    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: [dev_match] if dev_match else [])
+    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: ([dev_match] if dev_match else [], {}))
     monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
 
 def test_context_window_comes_from_endpoint_not_dev(monkeypatch):
@@ -116,9 +116,8 @@ def test_no_change_when_values_already_match(monkeypatch):
 
 def _patch_price(monkeypatch, dev_models, dev_match):
     monkeypatch.setattr(model_sync, "fetch_endpoint_model", lambda ep: None)
-    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: dev_models)
+    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: (dev_models, model_sync._build_price_index(dev_models)))
     monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
-    monkeypatch.setattr(model_sync, "_cache", {"data": dev_models, "ts": 0.0, "index": model_sync._build_price_index(dev_models)})
 
 
 def test_price_averaged_across_providers(monkeypatch):
@@ -282,9 +281,8 @@ def test_get_model_info_fallback(monkeypatch):
 
 def _patch_ep(monkeypatch, ep_model, dev_match):
     monkeypatch.setattr(model_sync, "fetch_endpoint_model", lambda ep: ep_model)
-    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: [dev_match] if dev_match else [])
+    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: ([dev_match] if dev_match else [], {}))
     monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
-    monkeypatch.setattr(model_sync, "_cache", {"data": [], "ts": 0.0, "index": {}})
 
 
 def test_server_embedding_sets_text_in_empty_out(monkeypatch):

--- a/tests/unit/test_model_sync.py
+++ b/tests/unit/test_model_sync.py
@@ -7,7 +7,6 @@ def _patch(monkeypatch, ep_model, dev_match):
     monkeypatch.setattr(model_sync, "get_modelsdev", lambda: [dev_match] if dev_match else [])
     monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
 
-
 def test_context_window_comes_from_endpoint_not_dev(monkeypatch):
     """The endpoint's max_model_len wins over models.dev limit.context."""
     _patch(monkeypatch,
@@ -113,3 +112,187 @@ def test_no_change_when_values_already_match(monkeypatch):
     })
     assert "context_window" not in result["updates"]
     assert "max_output_tokens" not in result["updates"]
+
+
+def _patch_price(monkeypatch, dev_models, dev_match):
+    monkeypatch.setattr(model_sync, "fetch_endpoint_model", lambda ep: None)
+    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: dev_models)
+    monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
+
+
+def test_price_averaged_across_providers(monkeypatch):
+    """Pricing is the mean of every provider's >0 cost for the same base model."""
+    dev_models = [
+        {"id": "openai/gpt-4o", "cost": {"input": 2.5, "output": 10}},
+        {"id": "azure/gpt-4o", "cost": {"input": 3.5, "output": 12}},
+        {"id": "github/gpt-4o", "cost": {"input": 0, "output": 12}},  # 0 input excluded
+    ]
+    _patch_price(monkeypatch, dev_models, dev_models[0])
+    result = model_sync.sync_model({"name": "gpt-4o", "endpoints": [{"url": "http://x"}]})
+    assert result["updates"]["input_cost_per_million"] == 3.0          # mean(2.5, 3.5)
+    assert result["updates"]["output_cost_per_million"] == round(34 / 3, 6)  # mean(10, 12, 12)
+
+
+def test_price_zero_listing_excluded(monkeypatch):
+    """A provider listing $0 is dropped from the average, not treated as free."""
+    dev_models = [
+        {"id": "p/llama-3.3-70b", "cost": {"input": 0, "output": 0}},
+        {"id": "q/llama-3.3-70b", "cost": {"input": 1.2, "output": 1.8}},
+    ]
+    _patch_price(monkeypatch, dev_models, dev_models[1])
+    result = model_sync.sync_model({"name": "llama-3.3-70b", "endpoints": [{"url": "http://x"}]})
+    assert result["updates"]["input_cost_per_million"] == 1.2
+    assert result["updates"]["output_cost_per_million"] == 1.8
+
+
+def test_no_price_update_when_all_zero(monkeypatch):
+    """If every provider lists $0, no cost update is proposed (never 0)."""
+    dev_models = [{"id": "p/m", "cost": {"input": 0, "output": 0}}]
+    _patch_price(monkeypatch, dev_models, dev_models[0])
+    result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
+    assert "input_cost_per_million" not in result["updates"]
+    assert "output_cost_per_million" not in result["updates"]
+
+
+def test_price_overwrites_stale_operator_value(monkeypatch):
+    """A trusted match corrects a stale/zero operator-set price."""
+    dev_models = [{"id": "p/m", "cost": {"input": 5.0, "output": 15.0}}]
+    _patch_price(monkeypatch, dev_models, dev_models[0])
+    result = model_sync.sync_model({
+        "name": "m",
+        "input_cost_per_million": 0,
+        "output_cost_per_million": 0,
+        "endpoints": [{"url": "http://x"}],
+    })
+    assert result["updates"]["input_cost_per_million"] == 5.0
+    assert result["updates"]["output_cost_per_million"] == 15.0
+
+
+def test_price_untouched_without_dev_match(monkeypatch):
+    """No models.dev match → operator-set pricing is preserved."""
+    _patch(monkeypatch, ep_model={"id": "m", "max_model_len": 4096}, dev_match=None)
+    result = model_sync.sync_model({
+        "name": "m",
+        "input_cost_per_million": 0,
+        "output_cost_per_million": 0,
+        "endpoints": [{"url": "http://x"}],
+    })
+    assert "input_cost_per_million" not in result["updates"]
+    assert "output_cost_per_million" not in result["updates"]
+
+
+# ── fetch_endpoint_model: SGLang /get_server_info first ────────────────────────
+
+class _Resp:
+    def __init__(self, payload, ok=True):
+        self._p = payload
+        self.ok = ok
+    def json(self):
+        if not self.ok:
+            raise ValueError("http error")
+        return self._p
+
+
+def test_sglang_server_info_preferred_over_v1_models(monkeypatch):
+    """/get_server_info is called first; when it 200s, /v1/models is never hit.
+    SGLang's max_req_input_len wins over /v1/models' theoretical max_model_len."""
+    calls = []
+    def fake_get(url, **kw):
+        calls.append(url)
+        if url.endswith("/get_server_info"):
+            return _Resp({"max_req_input_len": 500410, "served_model_name": "zai-org/GLM-5.2-FP8",
+                          "is_embedding": False, "enable_multimodal": None})
+        return _Resp({"data": [{"id": "zai-org/GLM-5.2-FP8", "max_model_len": 1048576}]})
+    monkeypatch.setattr(model_sync.requests, "get", fake_get)
+    r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
+    assert r["max_model_len"] == 500410
+    assert r["id"] == "zai-org/GLM-5.2-FP8"
+    assert r["is_embedding"] is False
+    assert r["enable_multimodal"] is None
+    assert not any(u.endswith("/models") for u in calls), "v1/models must not be called when server_info succeeds"
+
+
+def test_vllm_used_when_server_info_absent(monkeypatch):
+    """vLLM has no /get_server_info (404) → fall back to /v1/models max_model_len."""
+    def fake_get(url, **kw):
+        if url.endswith("/get_server_info"):
+            return _Resp({}, ok=False)  # 404
+        if url.endswith("/models"):
+            return _Resp({"data": [{"id": "m", "max_model_len": 32768}]})
+        return _Resp({}, ok=False)
+    monkeypatch.setattr(model_sync.requests, "get", fake_get)
+    r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
+    assert r["max_model_len"] == 32768
+    assert r["id"] == "m"
+    assert "enable_multimodal" not in r  # no server flags on the vLLM path
+
+
+def test_get_model_info_fallback(monkeypatch):
+    """Older SGLang with neither /get_server_info nor /v1/models max_model_len
+    → /get_model_info context_length is used."""
+    def fake_get(url, **kw):
+        if url.endswith("/get_server_info"):
+            return _Resp({}, ok=False)
+        if url.endswith("/models"):
+            return _Resp({"data": [{"id": "m"}]})  # no max_model_len
+        if url.endswith("/get_model_info"):
+            return _Resp({"context_length": 8192, "model_path": "m"})
+        return _Resp({}, ok=False)
+    monkeypatch.setattr(model_sync.requests, "get", fake_get)
+    r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
+    assert r["max_model_len"] == 8192
+
+
+# ── server-authoritative modalities ───────────────────────────────────────────
+
+def _patch_ep(monkeypatch, ep_model, dev_match):
+    monkeypatch.setattr(model_sync, "fetch_endpoint_model", lambda ep: ep_model)
+    monkeypatch.setattr(model_sync, "get_modelsdev", lambda: [dev_match] if dev_match else [])
+    monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
+
+
+def test_server_embedding_sets_text_in_empty_out(monkeypatch):
+    """is_embedding=True from SGLang → input=['text'], output=[] (authoritative)."""
+    _patch_ep(monkeypatch,
+              ep_model={"id": "m", "max_model_len": 8192, "is_embedding": True, "enable_multimodal": None},
+              dev_match={"modalities": {"input": ["text"], "output": ["text"]}})
+    result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
+    assert result["updates"]["input_modalities"] == ["text"]
+    assert result["updates"]["output_modalities"] == []
+
+
+def test_server_multimodal_disabled_strips_image(monkeypatch):
+    """enable_multimodal=null on the server vetoes models.dev's image claim."""
+    _patch_ep(monkeypatch,
+              ep_model={"id": "m", "max_model_len": 32768, "is_embedding": False, "enable_multimodal": None},
+              dev_match={"modalities": {"input": ["text", "image"], "output": ["text"]}})
+    result = model_sync.sync_model({"name": "m", "input_modalities": ["text", "image"],
+                                    "endpoints": [{"url": "http://x"}]})
+    assert result["updates"]["input_modalities"] == ["text"]
+
+
+def test_server_multimodal_enabled_adds_image(monkeypatch):
+    """enable_multimodal=True + models.dev says text only → ensure image present."""
+    _patch_ep(monkeypatch,
+              ep_model={"id": "m", "max_model_len": 32768, "is_embedding": False, "enable_multimodal": True},
+              dev_match={"modalities": {"input": ["text"], "output": ["text"]}})
+    result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
+    assert "image" in result["updates"]["input_modalities"]
+
+
+def test_server_multimodal_enabled_keeps_dev_image(monkeypatch):
+    """enable_multimodal=True + models.dev already lists image → no double-add."""
+    _patch_ep(monkeypatch,
+              ep_model={"id": "m", "max_model_len": 32768, "is_embedding": False, "enable_multimodal": True},
+              dev_match={"modalities": {"input": ["text", "image"], "output": ["text"]}})
+    result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
+    assert result["updates"]["input_modalities"] == ["text", "image"]
+
+
+def test_vllm_modalities_use_dev_only(monkeypatch):
+    """vLLM path (no enable_multimodal key) → models.dev modalities win, no veto."""
+    _patch_ep(monkeypatch,
+              ep_model={"id": "m", "max_model_len": 32768},  # vLLM: no server flags
+              dev_match={"modalities": {"input": ["text", "image"], "output": ["text"]}})
+    result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
+    assert result["updates"]["input_modalities"] == ["text", "image"]

--- a/tests/unit/test_model_sync.py
+++ b/tests/unit/test_model_sync.py
@@ -118,6 +118,7 @@ def _patch_price(monkeypatch, dev_models, dev_match):
     monkeypatch.setattr(model_sync, "fetch_endpoint_model", lambda ep: None)
     monkeypatch.setattr(model_sync, "get_modelsdev", lambda: dev_models)
     monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
+    monkeypatch.setattr(model_sync, "_cache", {"data": dev_models, "ts": 0.0, "index": model_sync._build_price_index(dev_models)})
 
 
 def test_price_averaged_across_providers(monkeypatch):
@@ -207,9 +208,43 @@ def test_sglang_server_info_preferred_over_v1_models(monkeypatch):
     r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
     assert r["max_model_len"] == 500410
     assert r["id"] == "zai-org/GLM-5.2-FP8"
+    assert r["backend"] == "sglang"
     assert r["is_embedding"] is False
     assert r["enable_multimodal"] is None
     assert not any(u.endswith("/models") for u in calls), "v1/models must not be called when server_info succeeds"
+
+
+def test_sglang_server_info_without_max_req_input_len_preserves_flags(monkeypatch):
+    """A 200 from /get_server_info without max_req_input_len (e.g. embedding-only
+    SGLang) must still carry is_embedding/enable_multimodal through the fallback
+    chain — the flags are the point of this PR, they must not be silently dropped."""
+    def fake_get(url, **kw):
+        if url.endswith("/get_server_info"):
+            return _Resp({"served_model_name": "m", "is_embedding": True, "enable_multimodal": None})  # no max_req_input_len
+        if url.endswith("/models"):
+            return _Resp({"data": [{"id": "m", "max_model_len": 8192}]})
+        return _Resp({}, ok=False)
+    monkeypatch.setattr(model_sync.requests, "get", fake_get)
+    r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
+    assert r["backend"] == "sglang"
+    assert r["is_embedding"] is True
+    assert r["max_model_len"] == 8192  # fell through to /v1/models
+
+
+def test_sglang_flags_returned_even_without_any_context_length(monkeypatch):
+    """If no source yields a context length but /get_server_info 200'd, the
+    flags are still returned (max_model_len=None) so the modality override fires."""
+    def fake_get(url, **kw):
+        if url.endswith("/get_server_info"):
+            return _Resp({"is_embedding": False, "enable_multimodal": True})  # no max_req_input_len
+        if url.endswith("/models"):
+            return _Resp({"data": [{"id": "m"}]})  # no max_model_len
+        return _Resp({}, ok=False)  # /get_model_info 404
+    monkeypatch.setattr(model_sync.requests, "get", fake_get)
+    r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
+    assert r["backend"] == "sglang"
+    assert r["enable_multimodal"] is True
+    assert r["max_model_len"] is None
 
 
 def test_vllm_used_when_server_info_absent(monkeypatch):
@@ -224,7 +259,7 @@ def test_vllm_used_when_server_info_absent(monkeypatch):
     r = model_sync.fetch_endpoint_model({"url": "http://x", "api_key": "k"})
     assert r["max_model_len"] == 32768
     assert r["id"] == "m"
-    assert "enable_multimodal" not in r  # no server flags on the vLLM path
+    assert "backend" not in r  # vLLM path: no sglang flags
 
 
 def test_get_model_info_fallback(monkeypatch):
@@ -249,12 +284,13 @@ def _patch_ep(monkeypatch, ep_model, dev_match):
     monkeypatch.setattr(model_sync, "fetch_endpoint_model", lambda ep: ep_model)
     monkeypatch.setattr(model_sync, "get_modelsdev", lambda: [dev_match] if dev_match else [])
     monkeypatch.setattr(model_sync, "find_in_modelsdev", lambda *a, **k: dev_match)
+    monkeypatch.setattr(model_sync, "_cache", {"data": [], "ts": 0.0, "index": {}})
 
 
 def test_server_embedding_sets_text_in_empty_out(monkeypatch):
     """is_embedding=True from SGLang → input=['text'], output=[] (authoritative)."""
     _patch_ep(monkeypatch,
-              ep_model={"id": "m", "max_model_len": 8192, "is_embedding": True, "enable_multimodal": None},
+              ep_model={"id": "m", "max_model_len": 8192, "backend": "sglang", "is_embedding": True, "enable_multimodal": None},
               dev_match={"modalities": {"input": ["text"], "output": ["text"]}})
     result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
     assert result["updates"]["input_modalities"] == ["text"]
@@ -264,7 +300,7 @@ def test_server_embedding_sets_text_in_empty_out(monkeypatch):
 def test_server_multimodal_disabled_strips_image(monkeypatch):
     """enable_multimodal=null on the server vetoes models.dev's image claim."""
     _patch_ep(monkeypatch,
-              ep_model={"id": "m", "max_model_len": 32768, "is_embedding": False, "enable_multimodal": None},
+              ep_model={"id": "m", "max_model_len": 32768, "backend": "sglang", "is_embedding": False, "enable_multimodal": None},
               dev_match={"modalities": {"input": ["text", "image"], "output": ["text"]}})
     result = model_sync.sync_model({"name": "m", "input_modalities": ["text", "image"],
                                     "endpoints": [{"url": "http://x"}]})
@@ -274,7 +310,7 @@ def test_server_multimodal_disabled_strips_image(monkeypatch):
 def test_server_multimodal_enabled_adds_image(monkeypatch):
     """enable_multimodal=True + models.dev says text only → ensure image present."""
     _patch_ep(monkeypatch,
-              ep_model={"id": "m", "max_model_len": 32768, "is_embedding": False, "enable_multimodal": True},
+              ep_model={"id": "m", "max_model_len": 32768, "backend": "sglang", "is_embedding": False, "enable_multimodal": True},
               dev_match={"modalities": {"input": ["text"], "output": ["text"]}})
     result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
     assert "image" in result["updates"]["input_modalities"]
@@ -283,16 +319,16 @@ def test_server_multimodal_enabled_adds_image(monkeypatch):
 def test_server_multimodal_enabled_keeps_dev_image(monkeypatch):
     """enable_multimodal=True + models.dev already lists image → no double-add."""
     _patch_ep(monkeypatch,
-              ep_model={"id": "m", "max_model_len": 32768, "is_embedding": False, "enable_multimodal": True},
+              ep_model={"id": "m", "max_model_len": 32768, "backend": "sglang", "is_embedding": False, "enable_multimodal": True},
               dev_match={"modalities": {"input": ["text", "image"], "output": ["text"]}})
     result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
     assert result["updates"]["input_modalities"] == ["text", "image"]
 
 
 def test_vllm_modalities_use_dev_only(monkeypatch):
-    """vLLM path (no enable_multimodal key) → models.dev modalities win, no veto."""
+    """vLLM path (no backend=sglang) → models.dev modalities win, no veto."""
     _patch_ep(monkeypatch,
-              ep_model={"id": "m", "max_model_len": 32768},  # vLLM: no server flags
+              ep_model={"id": "m", "max_model_len": 32768},  # vLLM: no backend key
               dev_match={"modalities": {"input": ["text", "image"], "output": ["text"]}})
     result = model_sync.sync_model({"name": "m", "endpoints": [{"url": "http://x"}]})
     assert result["updates"]["input_modalities"] == ["text", "image"]


### PR DESCRIPTION
## Summary

Three improvements to model sync (config editor **Update**/**Update All** buttons and the `sync_models.py` CLI):

### 1. Averaged pricing from models.dev
Input/output cost is now the **average** across every provider listing the same base model, excluding $0 listings (which are not real prices and would skew the average down). Previously pricing was not synced at all. On a trusted models.dev match it overwrites a stale or zero operator-set value the same way other fields are corrected.

### 2. SGLang `/get_server_info` queried first
`/get_server_info`'s `max_req_input_len` is the real per-request limit derived from the operator's `--context-length` and available KV cache — authoritative over `/v1/models`' `max_model_len`, which on SGLang reports the model's theoretical max (e.g. 1048576) rather than the configured window (e.g. ~500000). When `/get_server_info` succeeds, `/v1/models` is skipped entirely (one round-trip for SGLang).

### 3. SGLang capability flags authoritative for modalities
`is_embedding` and `enable_multimodal` from `/get_server_info` now override models.dev for modalities, since they reflect what the operator actually enabled on the serving backend:
- `is_embedding: true` → `output_modalities=[]`
- `enable_multimodal: null/false` → veto to text-only input (strips image even if models.dev claims it)
- `enable_multimodal: true` → ensure image is present in input_modalities

vLLM (which exposes no such flags) continues to use models.dev for modalities.

## Changed files
- `lumen/services/model_sync.py` — web process sync (used by config editor)
- `sync_models.py` — standalone CLI (mirrors same logic)
- `tests/unit/test_model_sync.py` — 23 tests covering pricing, server_info precedence, and modality veto/enforcement

## Verification
- `uv run python -m pytest tests/unit/test_model_sync.py` — 23 passed
- `uv run ruff check` — clean
- Live check against models.dev confirmed gpt-4o averaging across 16 providers (1 zero excluded → input=2.499929, output=9.999714)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>