### PR TITLE
Add project owner role for delegated manager administration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Lumen will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Projects can now have an **owner** — a manager who can additionally add/remove managers, transfer ownership, and activate/deactivate the project. Admins designate an owner at project creation (optional owner email field) or reassign it later via the "Make Owner" button on the project detail page. The owner is a flagged manager (`entity_managers.is_owner`), so all existing manager access continues to work unchanged. The owner cannot be removed directly; ownership must be transferred first.
+
 ## [1.22.0] - 2026-07-05
 
 ### Fixed

--- a/docs/dbschema.md
+++ b/docs/dbschema.md
@@ -134,6 +134,7 @@ erDiagram
         int id PK
         int user_entity_id FK
         int project_entity_id FK
+        boolean is_owner
     }
 
     model_stats {
@@ -468,13 +469,14 @@ Per-group model access overrides. Mirrors `entity_model_access` but applies to a
 
 ## entity_managers
 
-Maps users to the project entities they are permitted to manage. A manager can view and administer a project's API keys and usage.
+Maps users to the project entities they are permitted to manage. A manager can view and administer a project's API keys and usage. The `is_owner` flag designates the project owner — a manager who can additionally add/remove managers, transfer ownership, and activate/deactivate the project. At most one owner per project (enforced by app logic).
 
 | Column | Type | Nullable | Description |
 |--------|------|----------|-------------|
 | `id` | Integer | NO | Primary key |
 | `user_entity_id` | Integer (FK → entities) | NO | The user (must be `entity_type = 'user'`) who has management rights. Cascades on delete. |
 | `project_entity_id` | Integer (FK → entities) | NO | The project entity being managed. Cascades on delete. |
+| `is_owner` | Boolean | NO | True for the project owner; at most one owner per project (enforced by app logic). Default `false`. |
 
 **Constraints:** `UNIQUE(user_entity_id, project_entity_id)`
 

--- a/docs/projects/projects-detail.md
+++ b/docs/projects/projects-detail.md
@@ -21,27 +21,34 @@ The top row shows the project's activity and budget:
 
 Managers are the users responsible for a project. They can create and revoke API keys, grant model consent, and view usage — but they cannot manage other managers or deactivate the project.
 
-### Adding a Manager (admin only)
+One manager can be designated as the **owner**. The owner has all manager powers plus the ability to add/remove managers, transfer ownership, and activate/deactivate the project. Each project has at most one owner. The owner is marked with an **Owner** badge in the managers table.
+
+### Adding a Manager (admin or owner)
 
 1. Click **+ Add Manager**.
 2. A search dialog opens. Start typing a user's name or email.
 3. Select the user from the dropdown.
 4. Click **Add Manager**.
 
-### Removing a Manager (admin only)
+### Removing a Manager (admin or owner)
 
-Click **Remove** next to any manager in the table.
+Click **Remove** next to any manager in the table. The owner cannot be removed directly — you must transfer ownership to another manager first.
+
+### Transferring Ownership (admin or owner)
+
+Click **Make Owner** next to a non-owner manager to transfer ownership. The previous owner becomes a regular manager. If you are the current owner, transferring ownership means you will no longer be able to manage managers or toggle the project.
 
 ### What Managers Can Do
 
-| Action | Manager | Admin |
-|--------|---------|-------|
-| Create API keys for this project | ✓ | ✓ |
-| Revoke API keys for this project | ✓ | ✓ |
-| Grant model consent for this project | ✓ | ✓ |
-| View usage on this page | ✓ | ✓ |
-| Add / remove managers | — | ✓ |
-| Activate / deactivate the project | — | ✓ |
+| Action | Manager | Owner | Admin |
+|--------|---------|-------|-------|
+| Create API keys for this project | ✓ | ✓ | ✓ |
+| Revoke API keys for this project | ✓ | ✓ | ✓ |
+| Grant model consent for this project | ✓ | ✓ | ✓ |
+| View usage on this page | ✓ | ✓ | ✓ |
+| Add / remove managers | — | ✓ | ✓ |
+| Transfer ownership | — | ✓ | ✓ |
+| Activate / deactivate the project | — | ✓ | ✓ |
 
 ## API Keys
 

--- a/lumen/blueprints/projects/routes.py
+++ b/lumen/blueprints/projects/routes.py
@@ -401,7 +401,7 @@ def transfer_ownership(sid):
     new_assoc = db.session.execute(
         select(EntityManager).filter_by(user_entity_id=new_owner_id, project_entity_id=sid)
     ).scalar_one_or_none()
-    if new_assoc is old_owner_assoc:
+    if new_assoc is not None and new_assoc is old_owner_assoc:
         return jsonify({"error": "User is already the owner"}), HTTPStatus.CONFLICT
 
     if old_owner_assoc:

--- a/lumen/blueprints/projects/routes.py
+++ b/lumen/blueprints/projects/routes.py
@@ -11,7 +11,12 @@ from lumen.extensions import db
 from lumen.timeutils import utcnow
 from lumen.models.api_key import APIKey
 from lumen.models.entity import Entity
-from lumen.models.entity_manager import EntityManager, get_managed_projects
+from lumen.models.entity_manager import (
+    EntityManager,
+    get_managed_projects,
+    get_project_owner,
+    is_project_owner,
+)
 from lumen.models.entity_model_consent import EntityModelConsent
 from lumen.models.model_config import ModelConfig
 from lumen.models.entity_stat import EntityStat
@@ -34,6 +39,17 @@ def _require_project_access(entity_id: int, sid: int):
         ).scalar_one_or_none()
         if not assoc:
             abort(HTTPStatus.FORBIDDEN)
+
+
+def _require_project_admin(entity_id: int, sid: int):
+    """Abort 403 unless caller is a global admin or the project's owner.
+
+    Owner-level actions: add/remove managers, transfer ownership, toggle.
+    Regular managers (non-owners) are rejected here.
+    """
+    entity = db.session.get(Entity, entity_id)
+    if not is_admin(entity) and not is_project_owner(entity_id, sid):
+        abort(HTTPStatus.FORBIDDEN)
 
 
 def _scoped_project_ids(entity_id, entity):
@@ -180,18 +196,27 @@ def detail(sid):
         .order_by(Entity.name)
     ).scalars().all()
 
+    owner = get_project_owner(sid)
+    owner_id = owner.id if owner else None
+    entity = db.session.get(Entity, entity_id)
+    can_manage = is_admin(entity) or (owner_id == entity_id)
+
     return render_template(
         "project_detail.html",
         project=project,
         managers=managers,
+        owner_id=owner_id,
+        can_manage=can_manage,
         **data,
     )
 
 
 @projects_bp.route("/projects/<int:sid>/toggle", methods=["POST"])
-@admin_required
+@login_required
 def toggle_project(sid):
+    entity_id = session["entity_id"]
     project = db.first_or_404(select(Entity).filter_by(id=sid, entity_type="project"))
+    _require_project_admin(entity_id, sid)
     project.active = not project.active
     db.session.commit()
     return jsonify({"active": project.active})
@@ -205,6 +230,15 @@ def create_project():
     if not name:
         return jsonify({"error": "Project name required"}), HTTPStatus.BAD_REQUEST
 
+    owner_email = (data.get("owner_email") or "").strip()
+    owner_user = None
+    if owner_email:
+        owner_user = db.session.execute(
+            select(Entity).filter_by(email=owner_email, entity_type="user")
+        ).scalar_one_or_none()
+        if not owner_user:
+            return jsonify({"error": "Owner user not found"}), HTTPStatus.NOT_FOUND
+
     project = Entity(
         entity_type="project",
         name=name,
@@ -212,6 +246,15 @@ def create_project():
         active=True,
     )
     db.session.add(project)
+    db.session.flush()
+
+    if owner_user:
+        db.session.add(EntityManager(
+            user_entity_id=owner_user.id,
+            project_entity_id=project.id,
+            is_owner=True,
+        ))
+
     db.session.commit()
 
     # Record the project in config.yaml with an empty entry so the file always reflects
@@ -248,8 +291,11 @@ def delete_project(sid):
 
 
 @projects_bp.route("/projects/<int:sid>/users/search")
-@admin_required
+@login_required
 def search_project_users(sid):
+    entity_id = session["entity_id"]
+    _require_project_admin(entity_id, sid)
+
     q = (request.args.get("q") or "").strip()
     if len(q) < 2:
         return jsonify({"users": []})
@@ -279,8 +325,11 @@ def search_project_users(sid):
 
 
 @projects_bp.route("/projects/<int:sid>/users", methods=["POST"])
-@admin_required
+@login_required
 def add_project_manager(sid):
+    entity_id = session["entity_id"]
+    _require_project_admin(entity_id, sid)
+
     data = request.get_json() or {}
     email = (data.get("email") or "").strip()
     if not email:
@@ -306,8 +355,11 @@ def add_project_manager(sid):
 
 
 @projects_bp.route("/projects/<int:sid>/users/<int:uid>", methods=["DELETE"])
-@admin_required
+@login_required
 def remove_project_manager(sid, uid):
+    entity_id = session["entity_id"]
+    _require_project_admin(entity_id, sid)
+
     db.first_or_404(select(Entity).filter_by(id=sid, entity_type="project"))
 
     target_assoc = db.session.execute(
@@ -316,9 +368,55 @@ def remove_project_manager(sid, uid):
     if not target_assoc:
         return jsonify({"error": "Not found"}), HTTPStatus.NOT_FOUND
 
+    if target_assoc.is_owner:
+        return jsonify({"error": "Transfer ownership before removing the owner"}), HTTPStatus.CONFLICT
+
     db.session.delete(target_assoc)
     db.session.commit()
     return "", HTTPStatus.NO_CONTENT
+
+
+@projects_bp.route("/projects/<int:sid>/owner", methods=["POST"])
+@login_required
+def transfer_ownership(sid):
+    entity_id = session["entity_id"]
+    _require_project_admin(entity_id, sid)
+
+    data = request.get_json() or {}
+    new_owner_id = data.get("user_id")
+    if not new_owner_id:
+        return jsonify({"error": "user_id required"}), HTTPStatus.BAD_REQUEST
+
+    db.first_or_404(select(Entity).filter_by(id=sid, entity_type="project"))
+    new_owner = db.session.execute(
+        select(Entity).filter_by(id=new_owner_id, entity_type="user")
+    ).scalar_one_or_none()
+    if not new_owner:
+        return jsonify({"error": "User not found"}), HTTPStatus.NOT_FOUND
+
+    old_owner_assoc = db.session.execute(
+        select(EntityManager).filter_by(project_entity_id=sid, is_owner=True)
+    ).scalar_one_or_none()
+
+    new_assoc = db.session.execute(
+        select(EntityManager).filter_by(user_entity_id=new_owner_id, project_entity_id=sid)
+    ).scalar_one_or_none()
+    if new_assoc is old_owner_assoc:
+        return jsonify({"error": "User is already the owner"}), HTTPStatus.CONFLICT
+
+    if old_owner_assoc:
+        old_owner_assoc.is_owner = False
+    if new_assoc:
+        new_assoc.is_owner = True
+    else:
+        db.session.add(EntityManager(
+            user_entity_id=new_owner_id,
+            project_entity_id=sid,
+            is_owner=True,
+        ))
+
+    db.session.commit()
+    return jsonify({"owner_id": new_owner_id}), HTTPStatus.OK
 
 
 @projects_bp.route("/projects/<int:sid>/keys", methods=["POST"])

--- a/lumen/models/entity_manager.py
+++ b/lumen/models/entity_manager.py
@@ -18,6 +18,7 @@ class EntityManager(db.Model):
     id: Mapped[int] = mapped_column(db.Integer, primary_key=True, comment="Primary key")
     user_entity_id: Mapped[int] = mapped_column(db.Integer, db.ForeignKey("entities.id", ondelete="CASCADE"), comment="The user who has management rights over the project")
     project_entity_id: Mapped[int] = mapped_column(db.Integer, db.ForeignKey("entities.id", ondelete="CASCADE"), comment="The project entity being managed")
+    is_owner: Mapped[bool] = mapped_column(db.Boolean, default=False, nullable=False, comment="True for the project owner; at most one owner per project (enforced by app logic)")
 
     user: Mapped["Entity"] = relationship(foreign_keys=[user_entity_id], backref="managed_projects_assoc")
     project: Mapped["Entity"] = relationship(foreign_keys=[project_entity_id], backref="manager_assoc")
@@ -46,3 +47,27 @@ def get_managed_projects(user_entity_id: int):
         )
         .order_by(Entity.name)
     ).scalars().all()
+
+
+def get_project_owner(project_entity_id: int):
+    """The user Entity that owns this project, or None if no owner is set."""
+    return db.session.execute(
+        select(Entity)
+        .join(EntityManager, EntityManager.user_entity_id == Entity.id)
+        .where(
+            EntityManager.project_entity_id == project_entity_id,
+            EntityManager.is_owner == True,
+        )
+    ).scalar_one_or_none()
+
+
+def is_project_owner(user_entity_id: int, project_entity_id: int) -> bool:
+    """True if user_entity_id is the owner of project_entity_id."""
+    assoc = db.session.execute(
+        select(EntityManager).filter_by(
+            user_entity_id=user_entity_id,
+            project_entity_id=project_entity_id,
+            is_owner=True,
+        )
+    ).scalar_one_or_none()
+    return assoc is not None

--- a/lumen/templates/project_detail.html
+++ b/lumen/templates/project_detail.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-1">
   <a href="{{ url_for('projects.index') }}" class="btn btn-sm btn-outline-secondary">← Projects</a>
-  {% if is_admin %}
+  {% if can_manage %}
   {% if project.active %}
   <button class="btn btn-sm btn-outline-danger"
           onclick="toggleProject({{ project.id }}, true)">
@@ -98,7 +98,7 @@
 <!-- Managers -->
 <div class="d-flex justify-content-between align-items-center mt-4 mb-0">
   <h2 class="mb-0">Managers</h2>
-  {% if is_admin %}
+  {% if can_manage %}
   <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#addManagerModal"
           aria-haspopup="dialog">+ Add Manager</button>
   {% endif %}
@@ -110,24 +110,40 @@
       <tr>
         <th>Name</th>
         <th>Email</th>
-        {% if is_admin %}<th><span class="visually-hidden">Actions</span></th>{% endif %}
+        {% if can_manage %}<th><span class="visually-hidden">Actions</span></th>{% endif %}
       </tr>
     </thead>
     <tbody>
       {% for mgr in managers %}
       <tr>
-        <td>{% if is_admin %}<a href="{{ url_for('admin.user_profile', eid=mgr.id) }}">{{ mgr.name }}</a>{% else %}{{ mgr.name }}{% endif %}</td>
-        <td>{{ mgr.email or "—" }}</td>
-        {% if is_admin %}
         <td>
-          <button class="btn btn-sm btn-outline-danger"
-                  onclick="removeManager({{ project.id }}, {{ mgr.id }}, '{{ mgr.name | e }}')"
-                  aria-label="Remove {{ mgr.name }}">Remove</button>
+          {% if is_admin %}<a href="{{ url_for('admin.user_profile', eid=mgr.id) }}">{{ mgr.name }}</a>{% else %}{{ mgr.name }}{% endif %}
+          {% if mgr.id == owner_id %}<span class="badge bg-primary ms-1">Owner</span>{% endif %}
+        </td>
+        <td>{{ mgr.email or "—" }}</td>
+        {% if can_manage %}
+        <td>
+          <div class="d-flex gap-1 align-items-center">
+            {% if mgr.id == owner_id %}
+            <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top"
+                  title="Transfer ownership before removing">
+              <button class="btn btn-sm btn-outline-danger" disabled
+                      aria-label="Cannot remove owner {{ mgr.name }}">Remove</button>
+            </span>
+            {% else %}
+            <button class="btn btn-sm btn-outline-danger"
+                    onclick="removeManager({{ project.id }}, {{ mgr.id }}, '{{ mgr.name | e }}')"
+                    aria-label="Remove {{ mgr.name }}">Remove</button>
+            <button class="btn btn-sm btn-outline-primary"
+                    onclick="makeOwner({{ project.id }}, {{ mgr.id }}, '{{ mgr.name | e }}')"
+                    aria-label="Make {{ mgr.name }} the owner">Make Owner</button>
+            {% endif %}
+          </div>
         </td>
         {% endif %}
       </tr>
       {% else %}
-      <tr><td colspan="{{ 3 if is_admin else 2 }}" class="text-muted text-center">No managers assigned.</td></tr>
+      <tr><td colspan="{{ 3 if can_manage else 2 }}" class="text-muted text-center">No managers assigned.</td></tr>
       {% endfor %}
     </tbody>
   </table>
@@ -246,7 +262,7 @@
   </div>
 </div>
 
-{% if is_admin %}
+{% if can_manage %}
 <!-- Add Manager Modal -->
 {{ user_search_modal('addManagerModal', 'Add Manager', 'add-manager-email', 'manager-suggestions', 'add-manager-btn', 'Add Manager',
    'Search for a user by name or email address.') }}
@@ -559,7 +575,7 @@ document.getElementById("save-key-btn").addEventListener("click", async function
 });
 
 
-{% if is_admin %}
+{% if can_manage %}
 // Add manager — shared user-search typeahead (see static/js/user-search.js).
 const managerInput = document.getElementById("add-manager-email");
 const managerSearch = initUserSearch({
@@ -600,6 +616,18 @@ function removeManager(sid, uid, name) {
   if (!confirm(`Remove ${name} as manager?`)) return;
   fetch("/projects/" + sid + "/users/" + uid, { method: "DELETE", headers: { "X-CSRFToken": csrfToken } })
     .then(r => { if (r.ok) location.reload(); else alert("Failed to remove manager."); });
+}
+
+// Transfer ownership
+function makeOwner(sid, uid, name) {
+  if (!confirm(`Transfer ownership to ${name}? You will no longer be able to manage managers for this project.`)) return;
+  fetch("/projects/" + sid + "/owner", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-CSRFToken": csrfToken },
+    body: JSON.stringify({ user_id: uid }),
+  })
+    .then(r => { if (r.ok) location.reload(); else r.json().then(d => alert(d.error || "Failed to transfer ownership.")); })
+    .catch(() => alert("Failed to transfer ownership."));
 }
 
 // Toggle project active state

--- a/lumen/templates/projects.html
+++ b/lumen/templates/projects.html
@@ -112,8 +112,15 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <label for="project-name-input" class="form-label">Project name</label>
-        <input type="text" id="project-name-input" class="form-control" placeholder="e.g. research-bot">
+        <div class="mb-3">
+          <label for="project-name-input" class="form-label">Project name</label>
+          <input type="text" id="project-name-input" class="form-control" placeholder="e.g. research-bot">
+        </div>
+        <div class="mb-3">
+          <label for="project-owner-input" class="form-label">Owner email (optional)</label>
+          <input type="email" id="project-owner-input" class="form-control" placeholder="user@example.edu">
+          <div class="form-text">The owner can add/remove managers, transfer ownership, and activate/deactivate this project.</div>
+        </div>
       </div>
       <div class="modal-footer">
         <button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
@@ -323,10 +330,13 @@
 document.getElementById("create-project-btn").addEventListener("click", async function () {
   const name = document.getElementById("project-name-input").value.trim();
   if (!name) return;
+  const ownerEmail = document.getElementById("project-owner-input").value.trim();
+  const body = { name };
+  if (ownerEmail) body.owner_email = ownerEmail;
   const resp = await fetch("/projects", {
     method: "POST",
     headers: { "Content-Type": "application/json", "X-CSRFToken": csrfToken },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify(body),
   });
   if (resp.ok) {
     const data = await resp.json();

--- a/migrations/versions/d5e6f7a8b9c0_add_project_owner.py
+++ b/migrations/versions/d5e6f7a8b9c0_add_project_owner.py
@@ -1,0 +1,54 @@
+"""Add is_owner column to entity_managers
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-07-13 00:00:00.000000
+
+Adds a boolean ``is_owner`` column to ``entity_managers`` so a project can
+have a designated owner — a manager who can additionally add/remove other
+managers, transfer ownership, and activate/deactivate the project. At most
+one owner per project is enforced by app logic.
+
+SQLite dev uses ``create_all`` + stamp head and never runs this chain, so
+only the PostgreSQL path needs to be correct (matching c4d5e6f7a8b9).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d5e6f7a8b9c0"
+down_revision = "c4d5e6f7a8b9"
+branch_labels = None
+depends_on = None
+
+
+def _is_postgresql():
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _q(text):
+    """Escape a comment string for use in a PostgreSQL dollar-quoted literal."""
+    return f"$comment${text}$comment$"
+
+
+def upgrade():
+    with op.batch_alter_table("entity_managers") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_owner",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            )
+        )
+
+    if _is_postgresql():
+        op.execute(
+            f"COMMENT ON COLUMN entity_managers.is_owner IS "
+            f"{_q('True for the project owner; at most one owner per project (enforced by app logic)')}"
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("entity_managers") as batch_op:
+        batch_op.drop_column("is_owner")

--- a/tests/routes/test_projects_routes.py
+++ b/tests/routes/test_projects_routes.py
@@ -23,7 +23,7 @@ def service_project(app):
 
 @pytest.fixture
 def managed_project(app, service_project, test_user):
-    """service_project with test_user as manager."""
+    """service_project with test_user as manager (non-owner)."""
     with app.app_context():
         from lumen.extensions import db
         from lumen.models.entity_manager import EntityManager
@@ -33,6 +33,47 @@ def managed_project(app, service_project, test_user):
         ))
         db.session.commit()
     return service_project
+
+
+@pytest.fixture
+def owned_project(app, service_project, test_user):
+    """service_project with test_user as owner (is_owner=True)."""
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity_manager import EntityManager
+        db.session.add(EntityManager(
+            user_entity_id=test_user["id"],
+            project_entity_id=service_project["id"],
+            is_owner=True,
+        ))
+        db.session.commit()
+    return service_project
+
+
+@pytest.fixture
+def owner_auth_client(auth_client, owned_project):
+    """auth_client with test_user as owner of owned_project."""
+    return auth_client
+
+
+@pytest.fixture
+def second_user(app):
+    """A second user for transfer/add-manager tests."""
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity import Entity
+        entity = Entity(
+            entity_type="user",
+            email="second@example.com",
+            name="Second User",
+            initials="SU",
+            gravatar_hash="ghi789",
+            active=True,
+        )
+        db.session.add(entity)
+        db.session.commit()
+        db.session.refresh(entity)
+        return {"id": entity.id, "name": entity.name, "email": entity.email}
 
 
 @pytest.fixture
@@ -385,6 +426,176 @@ def test_remove_manager_not_found_returns_404(admin_client, service_project, tes
         f"/projects/{service_project['id']}/users/{test_user['id']}"
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Owner / project-admin functionality
+# ---------------------------------------------------------------------------
+
+def test_create_project_with_owner(app, admin_client, writable_config, test_user):
+    resp = admin_client.post("/projects", json={"name": "owned-svc", "owner_email": "testuser@example.com"})
+    assert resp.status_code == HTTPStatus.CREATED
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity import Entity
+        from lumen.models.entity_manager import EntityManager
+        project = db.session.execute(select(Entity).filter_by(name="owned-svc", entity_type="project")).scalar_one()
+        assoc = db.session.execute(
+            select(EntityManager).filter_by(user_entity_id=test_user["id"], project_entity_id=project.id)
+        ).scalar_one()
+        assert assoc.is_owner is True
+
+
+def test_create_project_owner_not_found_returns_404(admin_client, writable_config):
+    resp = admin_client.post("/projects", json={"name": "bad-owner", "owner_email": "nobody@example.com"})
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_create_project_without_owner_is_ownerless(app, admin_client, writable_config):
+    resp = admin_client.post("/projects", json={"name": "no-owner"})
+    assert resp.status_code == HTTPStatus.CREATED
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity import Entity
+        from lumen.models.entity_manager import EntityManager
+        project = db.session.execute(select(Entity).filter_by(name="no-owner", entity_type="project")).scalar_one()
+        count = db.session.scalar(
+            select(func.count()).select_from(EntityManager).filter_by(project_entity_id=project.id)
+        )
+        assert count == 0
+
+
+def test_owner_can_add_manager(owner_auth_client, owned_project, second_user):
+    resp = owner_auth_client.post(
+        f"/projects/{owned_project['id']}/users",
+        json={"email": "second@example.com"},
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+
+def test_owner_can_remove_manager(app, owner_auth_client, owned_project, second_user):
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity_manager import EntityManager
+        db.session.add(EntityManager(
+            user_entity_id=second_user["id"],
+            project_entity_id=owned_project["id"],
+        ))
+        db.session.commit()
+    resp = owner_auth_client.delete(
+        f"/projects/{owned_project['id']}/users/{second_user['id']}"
+    )
+    assert resp.status_code == HTTPStatus.NO_CONTENT
+
+
+def test_owner_cannot_remove_self(owner_auth_client, owned_project, test_user):
+    resp = owner_auth_client.delete(
+        f"/projects/{owned_project['id']}/users/{test_user['id']}"
+    )
+    assert resp.status_code == HTTPStatus.CONFLICT
+
+
+def test_owner_can_toggle(app, owner_auth_client, owned_project):
+    resp = owner_auth_client.post(f"/projects/{owned_project['id']}/toggle")
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.get_json()["active"] is False
+
+
+def test_non_owner_manager_cannot_toggle(managed_auth_client, managed_project):
+    resp = managed_auth_client.post(f"/projects/{managed_project['id']}/toggle")
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_non_owner_manager_cannot_add_manager(managed_auth_client, managed_project, second_user):
+    resp = managed_auth_client.post(
+        f"/projects/{managed_project['id']}/users",
+        json={"email": "second@example.com"},
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_owner_can_search_users(owner_auth_client, owned_project):
+    resp = owner_auth_client.get(f"/projects/{owned_project['id']}/users/search?q=test")
+    assert resp.status_code == HTTPStatus.OK
+
+
+def test_transfer_ownership(app, owner_auth_client, owned_project, test_user, second_user):
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity_manager import EntityManager
+        db.session.add(EntityManager(
+            user_entity_id=second_user["id"],
+            project_entity_id=owned_project["id"],
+            is_owner=False,
+        ))
+        db.session.commit()
+    resp = owner_auth_client.post(
+        f"/projects/{owned_project['id']}/owner",
+        json={"user_id": second_user["id"]},
+    )
+    assert resp.status_code == HTTPStatus.OK
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity_manager import EntityManager
+        old = db.session.execute(
+            select(EntityManager).filter_by(user_entity_id=test_user["id"], project_entity_id=owned_project["id"])
+        ).scalar_one()
+        new = db.session.execute(
+            select(EntityManager).filter_by(user_entity_id=second_user["id"], project_entity_id=owned_project["id"])
+        ).scalar_one()
+        assert old.is_owner is False
+        assert new.is_owner is True
+
+
+def test_transfer_to_non_manager_creates_manager(app, owner_auth_client, owned_project, test_user, second_user):
+    resp = owner_auth_client.post(
+        f"/projects/{owned_project['id']}/owner",
+        json={"user_id": second_user["id"]},
+    )
+    assert resp.status_code == HTTPStatus.OK
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity_manager import EntityManager
+        old = db.session.execute(
+            select(EntityManager).filter_by(user_entity_id=test_user["id"], project_entity_id=owned_project["id"])
+        ).scalar_one()
+        new = db.session.execute(
+            select(EntityManager).filter_by(user_entity_id=second_user["id"], project_entity_id=owned_project["id"])
+        ).scalar_one()
+        assert old.is_owner is False
+        assert new.is_owner is True
+
+
+def test_transfer_requires_owner_or_admin(managed_auth_client, managed_project, second_user):
+    resp = managed_auth_client.post(
+        f"/projects/{managed_project['id']}/owner",
+        json={"user_id": second_user["id"]},
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_transfer_unknown_user_returns_404(owner_auth_client, owned_project):
+    resp = owner_auth_client.post(
+        f"/projects/{owned_project['id']}/owner",
+        json={"user_id": 99999},
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_transfer_missing_user_id_returns_400(owner_auth_client, owned_project):
+    resp = owner_auth_client.post(
+        f"/projects/{owned_project['id']}/owner",
+        json={},
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_transfer_to_current_owner_returns_409(owner_auth_client, owned_project, test_user):
+    resp = owner_auth_client.post(
+        f"/projects/{owned_project['id']}/owner",
+        json={"user_id": test_user["id"]},
+    )
+    assert resp.status_code == HTTPStatus.CONFLICT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/test_projects_routes.py
+++ b/tests/routes/test_projects_routes.py
@@ -598,6 +598,34 @@ def test_transfer_to_current_owner_returns_409(owner_auth_client, owned_project,
     assert resp.status_code == HTTPStatus.CONFLICT
 
 
+def test_admin_assigns_owner_to_ownerless_project(app, admin_client, service_project, second_user):
+    """Admin can assign an owner to a project that has no owner, even when the
+    target user is not already a manager (the None-is-None edge case)."""
+    resp = admin_client.post(
+        f"/projects/{service_project['id']}/owner",
+        json={"user_id": second_user["id"]},
+    )
+    assert resp.status_code == HTTPStatus.OK
+    with app.app_context():
+        from lumen.extensions import db
+        from lumen.models.entity_manager import EntityManager
+        assoc = db.session.execute(
+            select(EntityManager).filter_by(
+                user_entity_id=second_user["id"], project_entity_id=service_project["id"]
+            )
+        ).scalar_one()
+        assert assoc.is_owner is True
+
+
+def test_plain_non_manager_forbidden_on_owner_routes(auth_client, service_project, second_user):
+    """A user who is neither admin, owner, nor manager gets 403 on owner-level routes."""
+    resp = auth_client.post(
+        f"/projects/{service_project['id']}/owner",
+        json={"user_id": second_user["id"]},
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
 # ---------------------------------------------------------------------------
 # API key management
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Each project can now have an **owner** — a manager who can additionally add/remove managers, transfer ownership, and activate/deactivate the project. Admins designate an owner at project creation (optional owner email field) or reassign it later via the "Make Owner" button on the project detail page.

The owner is stored as `is_owner` on `entity_managers` (a flagged manager), so all existing manager access logic (`_require_project_access`, `get_managed_projects`, nav cache) is unchanged. The owner simply passes the existing manager checks.

Closes #30.

## Design decisions

- **Storage:** `is_owner` boolean on `entity_managers` — owner is a flagged manager, single source of truth, auto-has access. One owner per project enforced by app logic.
- **Owner powers:** add/remove managers · transfer ownership · activate/deactivate. Not delete/create (those stay admin-only).
- **Assignment:** admin designates owner at create time (optional) and can reassign via transfer.
- **Removal:** owner cannot be removed directly — must transfer ownership first (409).
- **Owner-email-not-found on create:** returns 404 (consistent with `add_project_manager`), project is not created.
- **Transfer:** demote old owner + promote new in a single `db.session.commit()` — never zero or two owners.

## Changes

- **`lumen/models/entity_manager.py`** — `is_owner` column + `get_project_owner()` and `is_project_owner()` helpers.
- **`migrations/versions/d5e6f7a8b9c0_add_project_owner.py`** — adds `is_owner` boolean (NOT NULL, default false) to `entity_managers`. `down_revision = "c4d5e6f7a8b9"` (current head). PostgreSQL comment refresh; SQLite dev skips via `create_all`.
- **`lumen/blueprints/projects/routes.py`** — new `_require_project_admin()` (admin or owner); `create_project` accepts optional `owner_email`; `toggle_project`/`add_project_manager`/`remove_project_manager`/`search_project_users` switched from `@admin_required` to `@login_required` + `_require_project_admin`; `remove_project_manager` rejects owner removal (409); new `transfer_ownership` route (`POST /projects/<sid>/owner`); `detail` passes `owner_id` and `can_manage` to template.
- **`lumen/templates/project_detail.html`** — all manager-admin UI gated on `can_manage` (toggle button, add-manager button, actions column, modal markup, JS block). Owner row shows **Owner** badge + disabled Remove wrapped in a focusable tooltip span (WCAG: keyboard-accessible). Non-owner rows get **Make Owner** button with `confirm()`.
- **`lumen/templates/projects.html`** — create modal has optional "Owner email" field.
- **`tests/routes/test_projects_routes.py`** — 19 new tests + 3 new fixtures (`owned_project`, `owner_auth_client`, `second_user`).
- **`docs/dbschema.md`** — `is_owner` column added to ERD and table docs.
- **`docs/projects/projects-detail.md`** — updated permissions table (added Owner column), "Adding/Removing a Manager" → "(admin or owner)", new "Transferring Ownership" section.
- **`CHANGELOG.md`** — entry under `[Unreleased] → Added`.

## Verification

- [x] `uv run pytest` — 545 passed (19 new + 526 existing, 0 failures)
- [x] `gitnexus_detect_changes` — scope confirmed: only projects blueprint + model + tests + docs affected; no unexpected processes
- [x] Impact analysis on all changed route handlers: LOW risk (0 upstream callers each)
- [x] `_require_project_access` and `get_managed_projects` (HIGH label) need no changes — owner is a manager row, passes existing checks

## Test plan

- [ ] Manual: create project with owner email → owner badge appears, owner can add/remove managers
- [ ] Manual: log in as owner (non-admin) → can toggle project, add/remove managers, transfer ownership
- [ ] Manual: transfer ownership → old owner becomes plain manager, new owner gets badge + powers
- [ ] Manual: owner Remove button is disabled with tooltip "Transfer ownership before removing"
- [ ] Manual: regular manager (non-owner) → 403 on toggle/add-manager/transfer