### PR TITLE
Add R (ellmer) example to the Connect page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Lumen will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- The [Connect page](/connect) and Connect guide now include an **R** example, using the [ellmer](https://ellmer.tidyverse.org) package's `chat_openai_compatible()`. The tab follows the model selector (text and vision examples) and reads the key from `LUMEN_API_KEY` via `credentials`.
+
 ### Security
 
 - Fixed a stored XSS in the admin users table (`admin/users.html`). User display names (from the IdP) were interpolated into `innerHTML` unescaped, in both link text and `aria-label`/`title` attributes; a name containing markup could execute JavaScript in an admin's session. Names are now escaped with an `escHtml` helper.

--- a/docs/guides/connect.md
+++ b/docs/guides/connect.md
@@ -83,6 +83,34 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
+## R
+
+Use the [ellmer](https://ellmer.tidyverse.org) package with `chat_openai_compatible()` pointed at the Lumen base URL. The `credentials` function in the snippet below reads your key from the `LUMEN_API_KEY` environment variable.
+
+```r
+library(ellmer)
+
+chat <- chat_openai_compatible(
+  base_url = "https://lumen.example.com/v1",
+  name = "Lumen",
+  model = "MODEL",
+  credentials = function() Sys.getenv("LUMEN_API_KEY")
+)
+
+chat$chat("Hello!")
+```
+
+Instead of exporting `LUMEN_API_KEY` in your shell, you can store it in your R environment file: run `usethis::edit_r_environ()`, add a line `LUMEN_API_KEY="sk_…"`, save, and restart R.
+
+For image-capable models, pass an image alongside your prompt with `content_image_url()` (or `content_image_file()` for a local file):
+
+```r
+chat$chat(
+  "What is in this image?",
+  content_image_url("https://example.com/photo.jpg")
+)
+```
+
 ## Images and audio
 
 Models that accept images take standard OpenAI `image_url` content blocks in a chat request.

--- a/lumen/static/js/connect.js
+++ b/lumen/static/js/connect.js
@@ -212,6 +212,27 @@
       "print(result.text)";
   }
 
+  // ── R (ellmer) ───────────────────────────────────────────────────────────
+  function rSetup(id) {
+    return "library(ellmer)\n\n" +
+      "chat <- chat_openai_compatible(\n" +
+      '  base_url = "' + BASE + '",\n' +
+      '  name = "' + data.provider_name + '",\n' +
+      '  model = "' + id + '",\n' +
+      '  credentials = function() Sys.getenv("LUMEN_API_KEY")\n' +
+      ")\n";
+  }
+  function rText(id) {
+    return rSetup(id) + "\n" + 'chat$chat("Hello!")';
+  }
+  function rVision(id) {
+    return rSetup(id) + "\n" +
+      "chat$chat(\n" +
+      '  "What is in this image?",\n' +
+      '  content_image_url("https://example.com/photo.jpg")\n' +
+      ")";
+  }
+
   function render() {
     renderOpenCode();
 
@@ -232,16 +253,20 @@
 
     const curl = document.getElementById("examples-curl");
     const py = document.getElementById("examples-python");
+    const r = document.getElementById("examples-r");
     curl.innerHTML = "";
     py.innerHTML = "";
+    r.innerHTML = "";
 
     if (generic || hasText) {
       curl.appendChild(block("Chat completion", curlText(id)));
       py.appendChild(block("Chat completion", pyText(id)));
+      r.appendChild(block("Chat completion", rText(id)));
     }
     if (hasImage) {
       curl.appendChild(block("Vision (image input)", curlVision(id)));
       py.appendChild(block("Vision (image input)", pyVision(id)));
+      r.appendChild(block("Vision (image input)", rVision(id)));
     }
     if (hasAudio) {
       curl.appendChild(block("Audio in chat", curlAudioChat(id), null, AUDIO_NOTE));
@@ -251,6 +276,15 @@
     if (audioOnly) {
       curl.appendChild(block("Audio transcription", curlTranscribe(id)));
       py.appendChild(block("Audio transcription", pyTranscribe(id)));
+    }
+    // ellmer covers text and vision models; audio-only speech models have no R
+    // example, so leave a pointer rather than an empty pane.
+    if (!r.children.length) {
+      const note = document.createElement("p");
+      note.className = "text-muted small mb-0";
+      note.textContent = "This model's audio features aren't covered by the R examples. " +
+        "Use the curl or Python tab for audio models.";
+      r.appendChild(note);
     }
   }
 

--- a/lumen/templates/connect.html
+++ b/lumen/templates/connect.html
@@ -46,6 +46,10 @@ setx LUMEN_API_KEY "sk_…"        # Windows (new terminals)</code></pre>
       <button class="nav-link" id="tab-python" data-bs-toggle="tab" data-bs-target="#pane-python"
               type="button" role="tab" aria-controls="pane-python" aria-selected="false">Python</button>
     </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="tab-r" data-bs-toggle="tab" data-bs-target="#pane-r"
+              type="button" role="tab" aria-controls="pane-r" aria-selected="false">R</button>
+    </li>
   </ul>
 
   <div class="tab-content border border-top-0 rounded-bottom p-3">
@@ -71,6 +75,16 @@ setx LUMEN_API_KEY "sk_…"        # Windows (new terminals)</code></pre>
 
     <div class="tab-pane fade" id="pane-python" role="tabpanel" aria-labelledby="tab-python">
       <div id="examples-python"></div>
+    </div>
+
+    <div class="tab-pane fade" id="pane-r" role="tabpanel" aria-labelledby="tab-r">
+      <p class="text-muted small mb-2">
+        Uses the <a href="https://ellmer.tidyverse.org">ellmer</a> package. The snippet's
+        <code>credentials</code> function reads your key from the <code>LUMEN_API_KEY</code> environment
+        variable — set it with <code>usethis::edit_r_environ()</code> (add
+        <code>LUMEN_API_KEY="sk_…"</code>, save, then restart R), or export it before starting R.
+      </p>
+      <div id="examples-r"></div>
     </div>
 
   </div>


### PR DESCRIPTION
Closes #34.

## What

Adds an **R** tab to the `/connect` page (alongside OpenCode / curl / Python) and a matching section to the Connect guide, so R users have a copy-paste example for talking to Lumen's OpenAI-compatible API.

## Why

Requested in #34 — R is common for LLM-based text classification and other tasks, but the page didn't cover it. The example uses the [ellmer](https://ellmer.tidyverse.org) package's `chat_openai_compatible()`, as suggested by the issue author.

## Details

- The R tab follows the model selector like the curl/Python tabs:
  - **Text models** → a "Chat completion" example.
  - **Image models** → adds a "Vision (image input)" example using `content_image_url()`.
  - **Audio-only speech models** → shows a pointer to the curl/Python tabs instead of an empty pane.
- The key is read from `LUMEN_API_KEY` via an explicit `credentials = function() Sys.getenv("LUMEN_API_KEY")` function. Note: ellmer does **not** read that variable on its own — it works only because the snippet passes it through `credentials`. The intro note also mentions storing the key with `usethis::edit_r_environ()`.
- New `### Added` entry in CHANGELOG.md.

## Reviewer notes

- Verified the ellmer API (`chat_openai_compatible`, `content_image_url`) against its docs (v0.4.2) rather than from memory.
- The new tab uses the same ARIA `role="tab"` / `aria-controls` / `aria-labelledby` pattern as the existing tabs; existing connect-route and accessibility tests pass.
- Verified in the running dev app across text (`model-a`), vision (`vision-beta`), and audio-only (`granite-speech`) models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)